### PR TITLE
Add utils unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-  roots: ['<rootDir>/src'],
+  roots: ['<rootDir>/src', '<rootDir>/test'],
   testMatch: ['**/__tests__/**/*.test.ts', '**/?(*.)+(test).ts'],
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   testEnvironment: 'node',

--- a/test/utils/jwtUtility.test.ts
+++ b/test/utils/jwtUtility.test.ts
@@ -1,0 +1,18 @@
+import { generateToken, verifyToken } from '../../src/utils/jwtUtility';
+
+describe('jwtUtility', () => {
+  it('generates a token that can be verified', () => {
+    const token = generateToken(1, ['admin']);
+    const decoded = verifyToken(token);
+    expect(decoded).not.toBeNull();
+    if (decoded) {
+      expect(decoded.id).toBe(1);
+      expect(decoded.roles).toContain('admin');
+    }
+  });
+
+  it('returns null when token is invalid', () => {
+    const result = verifyToken('invalid.token');
+    expect(result).toBeNull();
+  });
+});

--- a/test/utils/logger.test.ts
+++ b/test/utils/logger.test.ts
@@ -1,0 +1,10 @@
+import logger from '../../src/utils/logger';
+
+describe('logger', () => {
+  it('exposes common logging methods', () => {
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.debug).toBe('function');
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.error).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- extend Jest roots to include a new `test` folder
- add unit tests for `jwtUtility`
- add unit tests for `logger`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a7eb252bc83319b489e84fc9b123e