### PR TITLE
Add basic service tests

### DIFF
--- a/test/services/adminService.test.ts
+++ b/test/services/adminService.test.ts
@@ -1,0 +1,33 @@
+import * as AdminService from '../../src/services/adminService';
+
+jest.mock('../../src/repositories/userRepository', () => ({
+  getUserByEmail: jest.fn(),
+}));
+jest.mock('../../src/repositories/adminRepository', () => ({
+  createUser: jest.fn(),
+}));
+jest.mock('../../src/services/authenticationService', () => ({
+  hashPassword: jest.fn(),
+}));
+jest.mock('../../src/config/config', () => ({ defaultUserPassword: 'p' }));
+jest.mock('../../src/plugin/logger', () => ({ buildLogger: () => ({ debug: jest.fn() }) }));
+
+const userRepo = require('../../src/repositories/userRepository');
+const adminRepo = require('../../src/repositories/adminRepository');
+const authSvc = require('../../src/services/authenticationService');
+
+describe('adminService.createUserService', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('creates a new user when none exists', async () => {
+    (userRepo.getUserByEmail as jest.Mock).mockResolvedValue(undefined);
+    (authSvc.hashPassword as jest.Mock).mockResolvedValue('h');
+    (adminRepo.createUser as jest.Mock).mockResolvedValue({ id: 1 });
+    await expect(AdminService.createUserService({ email: 'e', name:'n', lastname:'l' } as any)).resolves.toEqual({ id:1 });
+  });
+
+  it('throws error when user exists', async () => {
+    (userRepo.getUserByEmail as jest.Mock).mockResolvedValue({});
+    await expect(AdminService.createUserService({} as any)).rejects.toThrow('User with this email already exists');
+  });
+});

--- a/test/services/authenticationService.test.ts
+++ b/test/services/authenticationService.test.ts
@@ -1,0 +1,29 @@
+import * as AuthService from '../../src/services/authenticationService';
+import bcrypt from 'bcryptjs';
+
+jest.mock('bcryptjs');
+
+const bcryptMock = bcrypt as jest.Mocked<typeof bcrypt>;
+
+describe('authenticationService.verifyPassword', () => {
+  it('compares passwords using bcrypt', async () => {
+    bcryptMock.compare.mockResolvedValue(true as any);
+    await expect(AuthService.verifyPassword('a','b')).resolves.toBe(true);
+    expect(bcryptMock.compare).toHaveBeenCalledWith('a','b');
+  });
+
+  it('throws when bcrypt throws', async () => {
+    bcryptMock.compare.mockRejectedValue(new Error('bad'));
+    await expect(AuthService.verifyPassword('a','b')).rejects.toThrow('bad');
+  });
+});
+
+describe('authenticationService.hashPassword', () => {
+  it('hashes with salt', async () => {
+    bcryptMock.genSalt.mockResolvedValue('s' as any);
+    bcryptMock.hash.mockResolvedValue('h' as any);
+    await expect(AuthService.hashPassword('p')).resolves.toBe('h');
+    expect(bcryptMock.genSalt).toHaveBeenCalledWith(10);
+    expect(bcryptMock.hash).toHaveBeenCalledWith('p','s');
+  });
+});

--- a/test/services/eventInternsService.test.ts
+++ b/test/services/eventInternsService.test.ts
@@ -1,0 +1,3 @@
+describe('eventInternsService', () => {
+  test.todo('add tests for eventInternsService');
+});

--- a/test/services/eventsService.test.ts
+++ b/test/services/eventsService.test.ts
@@ -1,0 +1,3 @@
+describe('eventsService', () => {
+  test.todo('add tests for eventsService');
+});

--- a/test/services/graduationService.test.ts
+++ b/test/services/graduationService.test.ts
@@ -1,0 +1,3 @@
+describe('graduationService', () => {
+  test.todo('add tests for graduationService');
+});

--- a/test/services/internService.test.ts
+++ b/test/services/internService.test.ts
@@ -1,0 +1,3 @@
+describe('internService', () => {
+  test.todo('add tests for internService');
+});

--- a/test/services/mailerService.test.ts
+++ b/test/services/mailerService.test.ts
@@ -1,0 +1,42 @@
+import * as MailerService from '../../src/services/mailerService';
+
+jest.mock('../../src/plugin/mailer/mailerPlugin', () => ({
+  sendMail: jest.fn(),
+}));
+
+const mailerPlugin = require('../../src/plugin/mailer/mailerPlugin');
+
+describe('mailerService.sendMail', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls mailerPlugin.sendMail with given options', async () => {
+    const options = { to: 'a@b.com', recipientName: 'a', subject: 's', html: '<p>hi</p>' };
+    await MailerService.sendMail(options as any);
+    expect(mailerPlugin.sendMail).toHaveBeenCalledWith(options);
+  });
+
+  it('propagates errors from mailerPlugin', async () => {
+    (mailerPlugin.sendMail as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(MailerService.sendMail({} as any)).rejects.toThrow('fail');
+  });
+});
+
+describe('mailerService.sendStudentReviewEmail', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('builds options and delegates to sendMail', async () => {
+    const spy = jest.spyOn(MailerService, 'sendMail').mockResolvedValue();
+    await MailerService.sendStudentReviewEmail('e','n','sub','text');
+    expect(spy).toHaveBeenCalledWith({
+      to: 'e',
+      recipientName: 'n',
+      subject: 'sub',
+      html: 'text',
+    });
+  });
+
+  it('propagates errors from sendMail', async () => {
+    jest.spyOn(MailerService, 'sendMail').mockRejectedValue(new Error('err'));
+    await expect(MailerService.sendStudentReviewEmail('e','n','s','t')).rejects.toThrow('err');
+  });
+});

--- a/test/services/menuService.test.ts
+++ b/test/services/menuService.test.ts
@@ -1,0 +1,26 @@
+import * as MenuService from '../../src/services/menuService';
+
+jest.mock('../../src/repositories/userRepository', () => ({
+  getUserById: jest.fn(),
+}));
+jest.mock('../../src/repositories/permissionRepository', () => ({
+  getMenuItemsByRoleId: jest.fn(),
+}));
+
+const userRepo = require('../../src/repositories/userRepository');
+const permRepo = require('../../src/repositories/permissionRepository');
+
+describe('menuService.getMenuByRole', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns menu with role for existing user', async () => {
+    (userRepo.getUserById as jest.Mock).mockResolvedValue({ role_id: 2, role: 'r' });
+    (permRepo.getMenuItemsByRoleId as jest.Mock).mockResolvedValue(['m']);
+    await expect(MenuService.getMenuByRole(1)).resolves.toEqual({ role: 'r', menu: ['m'] });
+  });
+
+  it('throws when user not found', async () => {
+    (userRepo.getUserById as jest.Mock).mockResolvedValue(undefined);
+    await expect(MenuService.getMenuByRole(1)).rejects.toThrow('User not found');
+  });
+});

--- a/test/services/modalityService.test.ts
+++ b/test/services/modalityService.test.ts
@@ -1,0 +1,21 @@
+import * as ModalityService from '../../src/services/modalityService';
+
+jest.mock('../../src/repositories/modalityRepository', () => ({
+  getModalities: jest.fn(),
+}));
+
+const repo = require('../../src/repositories/modalityRepository');
+
+describe('modalityService.getGraduationProcessById', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns list from repository', async () => {
+    (repo.getModalities as jest.Mock).mockResolvedValue(['a']);
+    await expect(ModalityService.getGraduationProcessById()).resolves.toEqual(['a']);
+  });
+
+  it('propagates repository errors', async () => {
+    (repo.getModalities as jest.Mock).mockRejectedValue(new Error('oops'));
+    await expect(ModalityService.getGraduationProcessById()).rejects.toThrow('oops');
+  });
+});

--- a/test/services/permissionService.test.ts
+++ b/test/services/permissionService.test.ts
@@ -1,0 +1,37 @@
+import * as PermissionService from '../../src/services/permissionService';
+
+jest.mock('../../src/repositories/permissionRepository', () => ({
+  getRoleAndPermissions: jest.fn(),
+  getPermissions: jest.fn(),
+  getPermissionByID: jest.fn(),
+}));
+
+const repo = require('../../src/repositories/permissionRepository');
+
+describe('permissionService.getUserRolesAndPermissions', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns null when repository returns empty', async () => {
+    (repo.getRoleAndPermissions as jest.Mock).mockResolvedValue({});
+    await expect(PermissionService.getUserRolesAndPermissions(1)).resolves.toBeNull();
+  });
+
+  it('returns data when available', async () => {
+    (repo.getRoleAndPermissions as jest.Mock).mockResolvedValue({ id: 1 });
+    await expect(PermissionService.getUserRolesAndPermissions(1)).resolves.toEqual({ id: 1 });
+  });
+});
+
+describe('permissionService.getPermissions', () => {
+  it('forwards repository result', async () => {
+    (repo.getPermissions as jest.Mock).mockResolvedValue(['p']);
+    await expect(PermissionService.getPermissions()).resolves.toEqual(['p']);
+  });
+});
+
+describe('permissionService.getPermissionByID', () => {
+  it('forwards repository result', async () => {
+    (repo.getPermissionByID as jest.Mock).mockResolvedValue('perm');
+    await expect(PermissionService.getPermissionByID(1)).resolves.toBe('perm');
+  });
+});

--- a/test/services/professorService.test.ts
+++ b/test/services/professorService.test.ts
@@ -1,0 +1,3 @@
+describe('professorService', () => {
+  test.todo('add tests for professorService');
+});

--- a/test/services/rolesService.test.ts
+++ b/test/services/rolesService.test.ts
@@ -1,0 +1,50 @@
+import * as RolesService from '../../src/services/rolesService';
+
+jest.mock('../../src/repositories/rolesRepository', () => ({
+  getRoles: jest.fn(),
+  createRol: jest.fn(),
+  editRol: jest.fn(),
+  disableRol: jest.fn(),
+  addPermission: jest.fn(),
+  removePermission: jest.fn(),
+  getRolesProfessor: jest.fn(),
+  getRolesStudent: jest.fn(),
+}));
+
+const repo = require('../../src/repositories/rolesRepository');
+
+describe('rolesService.getRoles', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('filters roles by name and disabled status', async () => {
+    (repo.getRoles as jest.Mock).mockResolvedValue({
+      Admin: { id:1, disabled:false, permissions:{ page:['p'], actions:[] } },
+      Guest: { id:2, disabled:true },
+    });
+    await expect(RolesService.getRoles('Adm')).resolves.toEqual({
+      Admin: { id:1, disabled:false, permissions:{ page:['p'], actions:[] } },
+    });
+  });
+});
+
+describe('rolesService.createRol', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('creates role when name unique', async () => {
+    (repo.getRoles as jest.Mock).mockResolvedValue({});
+    (repo.createRol as jest.Mock).mockResolvedValue([{ id:3 }]);
+    await expect(RolesService.createRol({ name:'New' } as any)).resolves.toEqual({ id:3 });
+  });
+
+  it('throws when name exists', async () => {
+    (repo.getRoles as jest.Mock).mockResolvedValue({ Existing:{ id:1, disabled:false } });
+    await expect(RolesService.createRol({ name:'Existing' } as any)).rejects.toThrow('there is another Rol with the same name');
+  });
+});
+
+describe('rolesService.disableRol', () => {
+  it('returns repository result', async () => {
+    (repo.disableRol as jest.Mock).mockResolvedValue('ok');
+    await expect(RolesService.disableRol(1)).resolves.toBe('ok');
+  });
+});

--- a/test/services/statsService.test.ts
+++ b/test/services/statsService.test.ts
@@ -1,0 +1,21 @@
+import * as StatsService from '../../src/services/statsService';
+
+jest.mock('../../src/repositories/statsRepository', () => ({
+  getStats: jest.fn(),
+}));
+
+const repo = require('../../src/repositories/statsRepository');
+
+describe('statsService.getStats', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns data from repository', async () => {
+    (repo.getStats as jest.Mock).mockResolvedValue({ count: 1 });
+    await expect(StatsService.getStats()).resolves.toEqual({ count: 1 });
+  });
+
+  it('propagates repository errors', async () => {
+    (repo.getStats as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(StatsService.getStats()).rejects.toThrow('fail');
+  });
+});

--- a/test/services/studentService.test.ts
+++ b/test/services/studentService.test.ts
@@ -1,0 +1,50 @@
+import * as StudentService from '../../src/services/studentService';
+
+jest.mock('../../src/repositories/userRepository', () => ({
+  getStudents: jest.fn(),
+  getUserByEmail: jest.fn(),
+  getUserById: jest.fn(),
+  updateUser: jest.fn(),
+}));
+jest.mock('../../src/repositories/studentRepository', () => ({
+  storeStudent: jest.fn(),
+  getStudentById: jest.fn(),
+  updateStudent: jest.fn(),
+  getStudentByGraduation: jest.fn(),
+}));
+jest.mock('../../src/repositories/professorRepository', () => ({
+  deleteProfessor: jest.fn(),
+}));
+jest.mock('../../src/repositories/userProfileRepository', () => ({
+  getUserById: jest.fn(),
+}));
+jest.mock('../../src/plugin/logger', () => ({ buildLogger: () => ({ error: jest.fn(), debug: jest.fn() }) }));
+
+const userRepo = require('../../src/repositories/userRepository');
+const studentRepo = require('../../src/repositories/studentRepository');
+const professorRepo = require('../../src/repositories/professorRepository');
+const userProfileRepo = require('../../src/repositories/userProfileRepository');
+
+describe('studentService.getStudents', () => {
+  it('returns students', async () => {
+    (userRepo.getStudents as jest.Mock).mockResolvedValue(['s']);
+    await expect(StudentService.getStudents()).resolves.toEqual(['s']);
+  });
+});
+
+describe('studentService.createStudent', () => {
+  it('stores student', async () => {
+    (studentRepo.storeStudent as jest.Mock).mockResolvedValue({ id:1 });
+    await expect(StudentService.createStudent({ id:1, is_scholarship:true } as any)).resolves.toEqual({ id:1 });
+  });
+});
+
+describe('studentService.handleStudentUpdate', () => {
+  it('creates or updates student', async () => {
+    (professorRepo.deleteProfessor as jest.Mock).mockResolvedValue(undefined);
+    (studentRepo.getStudentById as jest.Mock).mockResolvedValue(null);
+    (studentRepo.storeStudent as jest.Mock).mockResolvedValue('ok');
+    await StudentService.handleStudentUpdate('1',{ is_scholarship:true });
+    expect(studentRepo.storeStudent).toHaveBeenCalled();
+  });
+});

--- a/test/services/userProfileService.test.ts
+++ b/test/services/userProfileService.test.ts
@@ -1,0 +1,45 @@
+import * as UserProfileService from '../../src/services/userProfileService';
+
+jest.mock('../../src/repositories/userProfileRepository', () => ({
+  createUserProfile: jest.fn(),
+  deleteUser: jest.fn(),
+  getUserById: jest.fn(),
+  getAllUsers: jest.fn(),
+  updateUserProfile: jest.fn(),
+  updateUserProfileRole: jest.fn(),
+}));
+jest.mock('../../src/repositories/userRolesRepository', () => ({
+  assignUserRole: jest.fn(),
+  deleteUserRole: jest.fn(),
+}));
+jest.mock('../../src/interactors/permissionsInteractor', () => ({
+  getRolesAndPermissions: jest.fn(),
+}));
+jest.mock('../../src/services/authenticationService', () => ({ hashPassword: jest.fn() }));
+jest.mock('../../src/config/config', () => ({ defaultUserPassword: 'p' }));
+jest.mock('../../src/plugin/logger', () => ({ buildLogger: () => ({ info: jest.fn(), debug: jest.fn(), error: jest.fn() }) }));
+
+const profileRepo = require('../../src/repositories/userProfileRepository');
+const permInteractor = require('../../src/interactors/permissionsInteractor');
+const authSvc = require('../../src/services/authenticationService');
+
+describe('userProfileService.createUserProfile', () => {
+  it('creates user profile with hashed password', async () => {
+    (authSvc.hashPassword as jest.Mock).mockResolvedValue('h');
+    (profileRepo.createUserProfile as jest.Mock).mockResolvedValue({ id:1 });
+    await expect(UserProfileService.createUserProfile({ name:'n', lastname:'l', mothername:'m', code:'c', email:'e', phone:'p', isStudent:true } as any)).resolves.toEqual({ id:1 });
+  });
+});
+
+describe('userProfileService.getUser', () => {
+  it('returns user with permissions', async () => {
+    (profileRepo.getUserById as jest.Mock).mockResolvedValue({ id:1 });
+    (permInteractor.getRolesAndPermissions as jest.Mock).mockResolvedValue('rp');
+    await expect(UserProfileService.getUser('1')).resolves.toEqual({ id:1, rolesAndPermissions:'rp' });
+  });
+
+  it('throws when not found', async () => {
+    (profileRepo.getUserById as jest.Mock).mockResolvedValue(null);
+    await expect(UserProfileService.getUser('2')).rejects.toThrow('User not found with such id 2');
+  });
+});

--- a/test/services/userRoleService.test.ts
+++ b/test/services/userRoleService.test.ts
@@ -1,0 +1,30 @@
+import * as UserRoleService from '../../src/services/userRoleService';
+
+jest.mock('../../src/repositories/userRolesRepository', () => ({
+  assignUserRole: jest.fn(),
+  deleteUserRole: jest.fn(),
+}));
+jest.mock('../../src/plugin/logger', () => ({ buildLogger: () => ({ debug: jest.fn(), info: jest.fn(), error: jest.fn() }) }));
+
+const repo = require('../../src/repositories/userRolesRepository');
+
+describe('userRoleService.createUserRole', () => {
+  it('delegates to repository', async () => {
+    (repo.assignUserRole as jest.Mock).mockResolvedValue('ok');
+    await expect(UserRoleService.createUserRole('1',2)).resolves.toBe('ok');
+  });
+});
+
+describe('userRoleService.createUserRoles', () => {
+  it('returns true when all assigned', async () => {
+    (repo.assignUserRole as jest.Mock).mockResolvedValue('ok');
+    await expect(UserRoleService.createUserRoles('1',[1,2])).resolves.toBe(true);
+  });
+});
+
+describe('userRoleService.deleteUserRole', () => {
+  it('calls repository', async () => {
+    await UserRoleService.deleteUserRole('3');
+    expect(repo.deleteUserRole).toHaveBeenCalledWith('3');
+  });
+});

--- a/test/services/userService.test.ts
+++ b/test/services/userService.test.ts
@@ -1,0 +1,68 @@
+import * as UserService from '../../src/services/userService';
+
+jest.mock('../../src/repositories/userRepository', () => ({
+  getUserByEmail: jest.fn(),
+  getUserByCode: jest.fn(),
+  createUser: jest.fn(),
+  getProfessors: jest.fn(),
+  getUserByRol: jest.fn(),
+  getProfessorById: jest.fn(),
+}));
+jest.mock('../../src/services/authenticationService', () => ({
+  hashPassword: jest.fn(),
+}));
+jest.mock('../../src/config/config', () => ({ defaultUserPassword: 'p' }));
+jest.mock('../../src/plugin/logger', () => ({ buildLogger: () => ({ debug: jest.fn(), info: jest.fn(), error: jest.fn() }) }));
+
+const repo = require('../../src/repositories/userRepository');
+const authSvc = require('../../src/services/authenticationService');
+
+describe('userService.findByEmail', () => {
+  it('calls repository', async () => {
+    (repo.getUserByEmail as jest.Mock).mockResolvedValue('u');
+    await expect(UserService.findByEmail('e')).resolves.toBe('u');
+  });
+});
+
+describe('userService.createUser', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('creates when email and code unique', async () => {
+    (repo.getUserByEmail as jest.Mock).mockResolvedValue(undefined);
+    (repo.getUserByCode as jest.Mock).mockResolvedValue(undefined);
+    (authSvc.hashPassword as jest.Mock).mockResolvedValue('h');
+    (repo.createUser as jest.Mock).mockResolvedValue({ id:1 });
+    await expect(UserService.createUser({ code:'c', lastname:'l', email:'e' } as any)).resolves.toEqual({ id:1 });
+  });
+
+  it('throws when email exists', async () => {
+    (repo.getUserByEmail as jest.Mock).mockResolvedValue({});
+    await expect(UserService.createUser({} as any)).rejects.toThrow('User with this email already exists');
+  });
+});
+
+describe('userService.getProfessors', () => {
+  it('returns professors', async () => {
+    (repo.getProfessors as jest.Mock).mockResolvedValue(['p']);
+    await expect(UserService.getProfessors()).resolves.toEqual(['p']);
+  });
+});
+
+describe('userService.getUserByRol', () => {
+  it('returns users by role', async () => {
+    (repo.getUserByRol as jest.Mock).mockResolvedValue(['u']);
+    await expect(UserService.getUserByRol(1)).resolves.toEqual(['u']);
+  });
+});
+
+describe('userService.getProfessorById', () => {
+  it('returns professor when found', async () => {
+    (repo.getProfessorById as jest.Mock).mockResolvedValue('prof');
+    await expect(UserService.getProfessorById('1')).resolves.toBe('prof');
+  });
+
+  it('throws when not found', async () => {
+    (repo.getProfessorById as jest.Mock).mockResolvedValue(undefined);
+    await expect(UserService.getProfessorById('1')).rejects.toThrow('No professor found');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit tests skeletons for service layer
- cover several services with basic success/error cases
- create placeholder todo tests for complex services

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683bc8d2b490833198d0bfb06e3c5162