### PR TITLE
fix: 676 - se corrigen errores múltiples al editar usuarios

### DIFF
--- a/src/interactors/userProfileInteractor.ts
+++ b/src/interactors/userProfileInteractor.ts
@@ -68,12 +68,15 @@ export const createUser = async (userData: any) => {
 export const updateUser = async (userId: string, userProfileData: any) => {
   try {
     const updatedUserProfile = await UserProfileService.updateUserProfile(userId, userProfileData);
+
     if (userProfileData.isStudent) {
       await StudentService.handleStudentUpdate(userId, userProfileData);
-    } else {
+    } else if (userProfileData.degree && userProfileData.department && userProfileData.specialty) {
       await ProfessorService.handleProfessorUpdate(userId, userProfileData);
     }
+
     await UserProfileService.updateUserRoles(userId, userProfileData.roles);
+
     return updatedUserProfile;
   } catch (error) {
     console.error('Error updating user:', error);


### PR DESCRIPTION
bug: Al intentar editar un usuario con rol de profesor, el sistema devolvía un error 500 cuando no se incluían los campos department, degree o specialty, ya que esos campos son requeridos en la tabla professors. Además, el cuerpo del request usaba una clave incorrecta (role_id en lugar de roles), lo que también causaba fallos en la actualización de roles.
<img width="679" alt="Screenshot 2025-06-11 at 5 54 23 PM" src="https://github.com/user-attachments/assets/a146a992-f0ee-4f9c-9209-c3a78c688f10" />
Fix: Se ajustó la lógica para que solo se intente actualizar la tabla professors cuando los campos department, degree y specialty estén presentes en el request. Además, se usó correctamente la clave roles en lugar de role_id para asegurar que la asignación de roles funcione como espera el backend.
<img width="681" alt="Screenshot 2025-06-11 at 5 55 43 PM" src="https://github.com/user-attachments/assets/7399cf84-3ed2-4142-b6c5-fb5a56098ccf" />
<img width="850" alt="Screenshot 2025-06-11 at 5 55 06 PM" src="https://github.com/user-attachments/assets/c9b2390f-8e92-4a15-8f95-c93de812e5cc" />
