### PR TITLE
#689 [13] El endpoint GET /interns/:id permite texto o decimales y responde como si fueran válidos

### DIFF
--- a/src/controllers/internController.ts
+++ b/src/controllers/internController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+import { BadRequestError } from '../errors/badRequestError';
 
 import {
   updateHours,
@@ -13,6 +14,11 @@ import {
 import { sendCreated, sendSuccess } from '../handlers/successHandler';
 import { handleError } from '../handlers/errorHandler';
 import { createInternInteractor } from '../interactors/internInteractor';
+
+const isNotID = (internIdString: string) => {
+  const interntIdNumber = Number(internIdString);
+  return isNaN(interntIdNumber) || interntIdNumber < 0 || interntIdNumber % 1 !== 0
+}
 
 export const updateHoursController = async (req: Request, res: Response) => {
   try {
@@ -48,6 +54,12 @@ export const getInternsByUserId = async (req: Request, res: Response) => {
 export const getInternsById = async (req: Request, res: Response) => {
   try {
     const { intern_id } = req.params;
+
+    if (isNotID(intern_id)) {
+      handleError(res, new BadRequestError("El ID debe ser un número entero"))
+      return
+    }
+
     const intern = await getInternById(parseInt(intern_id, 10));
     if (!intern) {
       return res.status(404).json({ success: false, message: 'Event not found' });

--- a/src/controllers/internController.ts
+++ b/src/controllers/internController.ts
@@ -39,6 +39,12 @@ export const updateHoursController = async (req: Request, res: Response) => {
 export const getInternsByUserId = async (req: Request, res: Response) => {
   try {
     const { user_id } = req.params;
+
+    if (isNotID(user_id)) {
+      handleError(res, new BadRequestError("El ID debe ser un número entero"))
+      return
+    }
+
     const intern = await getInternByUserId(parseInt(user_id, 10));
 
     if (!intern) {


### PR DESCRIPTION
# Bug
El endpoint permite parámetros decimales, con caracteres especiales y con letras y los procesa devolviendo un status 200 Ok en lugar de responer con un error 400 Bad Request. El sistema debería validar que se trata de un número entero positivo
![image](https://github.com/user-attachments/assets/afa9038b-50ca-4e6f-a059-c3f8c4c9f93b)

# Fix
Se agrega una pequeña función para confirmar que el string que se recibe se trate de un número ID válido, esta verificación devuelve un boolean. En un inicio se planteo la función como `isID`, pero como se busca encontrar los casos en los que el ID no es correcto para realizar una salida temprana, se factoriza el not dentro de la función, volviendola la función `isNotID`
```tsx
const isNotID = (internIdString: string) => {
  const interntIdNumber = Number(internIdString);
  return isNaN(interntIdNumber) || interntIdNumber < 0 || interntIdNumber % 1 !== 0
}
```
Dentro de la función `getInternsById ` se emplea la función para comprobar la validez del id, en caso de no ser válido se devuelve un error 400 y se termina la función:
```tsx
if (isNotID(intern_id)) {
      handleError(res, new BadRequestError("El ID debe ser un número entero"))
      return
    }
```

# Resultados
Todos los llamados incorrectos ahora retornan un error 400 Bad Request
![image](https://github.com/user-attachments/assets/dde23491-e022-42c3-89b6-005b10631ee5)
![image](https://github.com/user-attachments/assets/490deb84-7157-441f-84c2-da7f9e507e5e)
![image](https://github.com/user-attachments/assets/01bc90ee-d649-4c25-9dee-74a425a84921)
![image](https://github.com/user-attachments/assets/1f5486b2-4e98-47e9-87a4-0fd5b7398639)
