### PR TITLE
#692 [16] El endpoint DELETE /api/roles/:id acepta caracteres especiales, letras o espacios como valor del ID

### DIFF
--- a/src/controllers/rolesController.ts
+++ b/src/controllers/rolesController.ts
@@ -5,6 +5,9 @@ import { sendSuccess } from '../handlers/successHandler';
 import * as RolesInteractor from '../interactors/rolesInteractor';
 import Rol from '../models/rol';
 import rolePermissionsRequest from '../models/rolePermissionRequestInterface';
+import { BadRequestError } from '../errors/badRequestError';
+
+const regexRoleID = /^[0-9]+$/
 
 export const getRoles = async (req: Request, res: Response) => {
   const rolName = req.body.name;
@@ -53,6 +56,11 @@ export const editRol = async (req: Request, res: Response) => {
 };
 
 export const disableRol = async (req: Request, res: Response) => {
+  if (!regexRoleID.test(req.params.id)) {
+    handleError(res, new BadRequestError("El ID debe ser un número entero positivo"))
+    return
+  }
+  
   const id: number = parseInt(req.params.id);
   try {
     const disabledRol = await RolesInteractor.disableRol(id);


### PR DESCRIPTION
# Bug
La función `disableRol` permite parámetros inválidos y los trata como si fuesen válidos, respondiendo con códigos que no corresponden, en lugar de responder con un 400 Bad Request luego de recibir un parámetro inválido, se espera que se reciban número enteros positivos, sin caracteres especiales, letras ni decimales
![image](https://github.com/user-attachments/assets/6299cb8b-1661-4429-a92a-01662585b7f9)

# Fix
Se implemento una expresión regular para verificar que se introduzca un parámetro correcto:
```tsx
const regexRoleID = /^[0-9]+$/
```

Y se agrega una verificación a la función `disableRol`, en caso de no poder verificarse el ID, se retorna un error 400 Bad Request, caso contrario, se sigue con el flujo de código normal:
```tsx
if (!regexRoleID.test(req.params.id)) {
    handleError(res, new BadRequestError("El ID debe ser un número entero positivo"))
    return
  }
```

# Resultados
Las solicitudes con parámetros inválidos retornan el error 400 Bad Request, los parámetros validados siguen con la lógica ya implementada:
![image](https://github.com/user-attachments/assets/4e3a9550-6f8d-4cee-ba9a-a774f193c0de)
![image](https://github.com/user-attachments/assets/930bc816-7931-4632-b011-e1cda5337999)
![image](https://github.com/user-attachments/assets/4e981f40-d31e-492b-a631-0caaa24d374c)
![image](https://github.com/user-attachments/assets/4f7770d2-8800-44c5-8a9a-2518b6316d92)
![image](https://github.com/user-attachments/assets/d06c4419-d633-4bee-9db0-caa50d0b66c0)
