### PR TITLE
fix(#674): permitir borrar usuarios comunes bloquear eliminación de usuario admin

### DIFF
--- a/src/interactors/userProfileInteractor.ts
+++ b/src/interactors/userProfileInteractor.ts
@@ -3,6 +3,7 @@ import * as UserRoleService from '../services/userRoleService';
 import * as ProfessorService from '../services/professorService';
 import * as StudentService from '../services/studentService';
 import { NotFoundError } from '../errors/notFoundError';
+import db from '../repositories/pg-connection';
 
 export const deleteUser = async (userId: string) => {
   try {
@@ -11,7 +12,28 @@ export const deleteUser = async (userId: string) => {
     if (!user) {
       throw new NotFoundError('User not found');
     }
-
+    if (user.role_id === 1) {
+      const error = new Error("You cannot delete users with the 'admin' role. This role is protected.");
+      (error as any).statusCode = 403;
+      throw error;
+    }
+    if (user.role_id === 2) {
+      await db('graduation_process')
+        .where({ tutor_id: userId })
+        .update({ tutor_id: null });
+    
+      await db('graduation_process')
+        .where({ reviewer_id: userId })
+        .update({ reviewer_id: null });
+    
+      await db('professors').where({ id: userId }).delete();
+    }
+    if (user.role_id === 3) {
+      await db('graduation_process')
+        .where({ student_id: userId }).delete();
+      
+      await db('students').where({ id: userId }).delete();
+    }
     await UserProfileService.deleteUser(parseInt(userId));
     await UserRoleService.deleteUserRole(userId);
   } catch (error) {


### PR DESCRIPTION
Bug: El sistema daba un error cuando se intentaba eliminar usuarios con rol de profesor o estudiante.
Esto pasaba porque esos usuarios estaban conectados a otras tablas (como graduation_process) y no se podían borrar directamente.
También faltaba una validación para evitar que se eliminen usuarios con rol de administrador
Fix: Se agregó una validación para evitar que se eliminen usuarios con rol de administrador.
También se limpiaron correctamente las relaciones de profesores y estudiantes en la tabla graduation_process antes de eliminarlos.
Esto evita errores por claves foráneas y permite borrar usuarios comunes sin problemas.
<img width="829" alt="Screenshot 2025-06-12 at 2 48 51 PM" src="https://github.com/user-attachments/assets/8fd30841-bb28-4890-8634-da12308bf9e7" />
<img width="1263" alt="Screenshot 2025-06-12 at 2 48 34 PM" src="https://github.com/user-attachments/assets/c3bc24bf-eac7-4353-b77e-9b8dab7c4b7c" />
<img width="1265" alt="Screenshot 2025-06-12 at 1 01 22 PM" src="https://github.com/user-attachments/assets/d0c3684f-baa3-4320-a9e4-eb99443dc29e" />
<img width="1271" alt="Screenshot 2025-06-12 at 2 33 34 PM" src="https://github.com/user-attachments/assets/00a7ef8c-a7ce-45ed-9af5-acb403b5adbf" />
