### PR TITLE
fix: validar que existe id de intern en GET /interns/:id/my-events

### DIFF
--- a/src/controllers/internController.ts
+++ b/src/controllers/internController.ts
@@ -94,6 +94,11 @@ export const getMyEventsInternController = async (req: Request, res: Response) =
   try {
     const { intern_id } = req.params;
     const events = await getMyEventsInternService(parseInt(intern_id, 10));
+    const numericId = parseInt(intern_id, 10);
+    const intern = await getInternById(numericId);
+    if (!intern) {
+      return res.status(404).json({ message: 'Intern not found' });
+    }
     if (!events) {
       return res.status(404).json({ success: false, message: 'Interns process not found' });
     }


### PR DESCRIPTION
Bug: El endpoint GET /interns/:id/my-events devolvía una respuesta exitosa (200 OK) incluso cuando el intern_id no existía o no había eventos asociados, lo cual generaba resultados engañosos para el cliente.
Fix: Se agregó validación explícita para verificar si el interno existe antes de consultar sus eventos. Además, se retorna un 404 si el interno no tiene eventos asociados.
<img width="631" alt="Screenshot 2025-06-12 at 3 53 54 PM" src="https://github.com/user-attachments/assets/7c84c8a9-0a81-49e0-94e9-2d8c2e6ff963" />
<img width="1259" alt="Screenshot 2025-06-12 at 3 54 06 PM" src="https://github.com/user-attachments/assets/e7243351-8012-443c-940b-92ba30263b7e" />
