### PR TITLE
Fix/698 limit intern hours

### DIFF
--- a/src/controllers/internController.ts
+++ b/src/controllers/internController.ts
@@ -94,6 +94,11 @@ export const getMyEventsInternController = async (req: Request, res: Response) =
   try {
     const { intern_id } = req.params;
     const events = await getMyEventsInternService(parseInt(intern_id, 10));
+    const numericId = parseInt(intern_id, 10);
+    const intern = await getInternById(numericId);
+    if (!intern) {
+      return res.status(404).json({ message: 'Intern not found' });
+    }
     if (!events) {
       return res.status(404).json({ success: false, message: 'Interns process not found' });
     }

--- a/src/services/internService.ts
+++ b/src/services/internService.ts
@@ -14,8 +14,15 @@ import {
 export const updateHours = async (internId: number, type: string, duration_hours: number) => {
   try {
     if (type === 'accepted') {
-      const { total_hours, pending_hours } = await getInternById(internId);
-      var newPendingHours = pending_hours - duration_hours;
+      if (duration_hours <= 0) {
+        throw new Error('Hours must be a positive number');
+      }
+      const { total_hours, pending_hours, completed_hours } = await getInternById(internId);
+
+      if (completed_hours + duration_hours > total_hours) {
+        throw new Error('Intern has already completed the required hours');
+      }
+      let newPendingHours = pending_hours - duration_hours;
       if (newPendingHours < 0) {
         newPendingHours = 0;
       }
@@ -28,7 +35,7 @@ export const updateHours = async (internId: number, type: string, duration_hours
     }
   } catch (error) {
     console.error('Error in InternsService.updateHours', error);
-    throw new Error('Error fetching Update Hours Intern');
+    throw error;
   }
 };
 


### PR DESCRIPTION
Bug: El bug se encontraba en el endpoint PUT /interns/:id/update-hours, el cual permitía sumar horas negativas, lo que resultaba en una disminución de las horas completadas por el interno. Además, también permitía que se agregaran más horas de las necesarias, incluso cuando el interno ya había cumplido con el total de horas requeridas. Esta falta de validación generaba inconsistencias en el seguimiento del cumplimiento de horas de los internos.

Fix: agregar validaciones dentro del servicio updateHours. Se implementó una verificación para asegurar que el valor de horas ingresado sea mayor a cero. También se añadió una validación para impedir que la suma de las horas actuales con las nuevas horas supere el total de horas asignadas al interno. Con estos cambios, el sistema ahora rechaza de forma adecuada los valores inválidos y garantiza que no se exceda el límite de horas permitido.
<img width="777" alt="Screenshot 2025-06-12 at 4 27 03 PM" src="https://github.com/user-attachments/assets/4f04b56c-e01e-48ca-8b8a-cc07f03f0d33" />
<img width="853" alt="Screenshot 2025-06-12 at 4 26 38 PM" src="https://github.com/user-attachments/assets/44cb5bac-c29e-45ed-94df-a481ceb7237b" />
<img width="1267" alt="Screenshot 2025-06-12 at 4 34 33 PM" src="https://github.com/user-attachments/assets/d78a6ab0-c995-4bd8-baef-2acfe70df9b1" />


