### PR TITLE
Fix/693 endpoint delete permission message

### DIFF
--- a/src/controllers/rolesController.ts
+++ b/src/controllers/rolesController.ts
@@ -87,7 +87,10 @@ export const removePermission = async (req: Request, res: Response) => {
   try {
     const rolePermission = await RolesInteractor.removePermission(ides);
     if (!rolePermission) {
-      return res.status(404).json({ success: false, message: 'can not delet rol' });
+      return res.status(404).json({
+        success: false,
+        message: 'No se puede eliminar el permiso: el rol o la relación con el permiso no existe.',
+      });
     }
     sendSuccess(res, rolePermission, 'permission attach successfully');
   } catch (error) {

--- a/src/controllers/rolesController.ts
+++ b/src/controllers/rolesController.ts
@@ -5,6 +5,7 @@ import { sendSuccess } from '../handlers/successHandler';
 import * as RolesInteractor from '../interactors/rolesInteractor';
 import Rol from '../models/rol';
 import rolePermissionsRequest from '../models/rolePermissionRequestInterface';
+import * as RolesService from '../services/rolesService';
 
 export const getRoles = async (req: Request, res: Response) => {
   const rolName = req.body.name;
@@ -84,15 +85,28 @@ export const addPermission = async (req: Request, res: Response) => {
 
 export const removePermission = async (req: Request, res: Response) => {
   const ides: rolePermissionsRequest = req.body;
+
   try {
+    const { role_id } = ides;
+    const roles = await RolesService.getRoles('');
+    const targetRole = Object.values(roles).find(r => r.id === role_id);
+
+    if (!targetRole || targetRole.disabled) {
+      return res.status(400).json({
+        success: false,
+        message: 'No se puede eliminar el permiso porque el rol está deshabilitado o no existe.',
+      });
+    }
     const rolePermission = await RolesInteractor.removePermission(ides);
+
     if (!rolePermission) {
       return res.status(404).json({
         success: false,
-        message: 'No se puede eliminar el permiso: el rol o la relación con el permiso no existe.',
+        message: 'No se puede eliminar el permiso: la relación con el permiso no existe.',
       });
     }
-    sendSuccess(res, rolePermission, 'permission attach successfully');
+
+    sendSuccess(res, rolePermission, 'Permiso eliminado correctamente');
   } catch (error) {
     if (error instanceof Error) {
       handleError(res, error);


### PR DESCRIPTION
Bug:
El endpoint DELETE /api/roles/permissions/ permitía intentar eliminar permisos de roles deshabilitados, y cuando fallaba la operación, devolvía un mensaje genérico e impreciso: "can not delet rol". El controlador no verificaba si el rol estaba deshabilitado antes de intentar eliminar un permiso. Además, cualquier fallo en la operación devolvía un mensaje ambiguo


Fix:
Se agregó una validación previa que verifica si el rol existe y está habilitado antes de permitir la eliminación de un permiso. Además, se mejoró el mensaje de error existente para informar con mayor claridad cuando no se encuentra la relación entre el rol y el permiso.
<img width="757" alt="Screenshot 2025-06-12 at 8 28 12 PM" src="https://github.com/user-attachments/assets/deba6c7d-1c90-4df1-97b3-951f7f9c19c0" />
<img width="901" alt="Screenshot 2025-06-12 at 8 28 25 PM" src="https://github.com/user-attachments/assets/42aceb7b-5798-470d-a60a-8b42ab3b607f" />
