### PR TITLE
[14] El endpoint POST /api/roles permite crear roles con campos vacíos, caracteres especiales, números o un solo carácter

### DIFF
--- a/src/controllers/rolesController.ts
+++ b/src/controllers/rolesController.ts
@@ -48,6 +48,15 @@ export const createRol = async (req: Request, res: Response) => {
 };
 
 export const editRol = async (req: Request, res: Response) => {
+  const regexID = /^[0-9]{1,8}$/
+  if (!regexID.test(req.params.id)) {
+    handleError(res, new BadRequestError("El ID debe ser un número entero positivo"))
+    return
+  }
+  if (!isValidRoleData(req)) {
+    handleError(res, new BadRequestError("Datos inválidos, no ingrese números ni caracteres especiales"))
+    return
+  }
   const rolToEdit: Rol = req.body;
   const id: number = parseInt(req.params.id);
   try {

--- a/src/controllers/rolesController.ts
+++ b/src/controllers/rolesController.ts
@@ -5,6 +5,13 @@ import { sendSuccess } from '../handlers/successHandler';
 import * as RolesInteractor from '../interactors/rolesInteractor';
 import Rol from '../models/rol';
 import rolePermissionsRequest from '../models/rolePermissionRequestInterface';
+import { BadRequestError } from '../errors/badRequestError';
+
+const isValidRoleData = (req: Request) => {
+  const regex = /^[a-zA-Z]{4,16}$/
+  const {name, category} = req.body
+  return regex.test(name) && regex.test(category)
+}
 
 export const getRoles = async (req: Request, res: Response) => {
   const rolName = req.body.name;
@@ -22,6 +29,10 @@ export const getRoles = async (req: Request, res: Response) => {
 };
 
 export const createRol = async (req: Request, res: Response) => {
+  if (!isValidRoleData(req)) {
+    handleError(res, new BadRequestError("Datos inválidos, no ingrese números ni caracteres especiales"))
+    return
+  }
   const newRol: Rol = req.body;
   try {
     const rol = await RolesInteractor.createRol(newRol);


### PR DESCRIPTION
# Bug
El endpoint de creación de roles permite crear roles con información no validada, como campos vacíos, caracteres especiales o números:
![image](https://github.com/user-attachments/assets/2de5daec-e11e-407f-9167-57b4f49ddce2)

# Fix
Se agrega una función que emplea expresiones regulares para validar que tanto el nombre como la categoria estén conformadas únicamente por letras minúsculas y mayúsculas, permitiendo entre 4 y 16 caracteres.
```tsx
const isValidRoleData = (req: Request) => {
  const regex = /^[a-zA-Z]{4,16}$/
  const {name, category} = req.body
  return regex.test(name) && regex.test(category)
}
```
>[!Tip]
>El limite de caracteres es fácilmente modificable

Además, se agrega la verificación en el llamado a la función `createRol`, en caso de no ser una entrada válida, se retorna un error 400 Bad Request

# Resultados
![image](https://github.com/user-attachments/assets/dd2f4cce-2866-4181-8636-f7b8282b44e0)
![image](https://github.com/user-attachments/assets/0a26908e-ba22-4408-8168-741179518535)
![image](https://github.com/user-attachments/assets/9b0273cf-1ffe-4be3-acca-cea35d73a9b8)
![image](https://github.com/user-attachments/assets/9742e6ee-a2ee-46e8-b1f0-f6366e4b958f)


