### PR TITLE
fix(694): validación para intern_id inválido o no vinculado a event

### DIFF
--- a/src/controllers/eventInternsController.ts
+++ b/src/controllers/eventInternsController.ts
@@ -13,11 +13,28 @@ import {
 } from '../services/eventInternsService';
 import { sendCreated, sendSuccess } from '../handlers/successHandler';
 import { handleError } from '../handlers/errorHandler';
+import { getInternsById } from '../repositories/internsRepository';
 
 export const getEventInternController = async (req: Request, res: Response) => {
   try {
     const { id_evento, id_becario } = req.params;
-    const result = await getEventsInternById(parseInt(id_evento, 10), parseInt(id_becario, 10));
+    const eventId = parseInt(id_evento, 10);
+    const internId = parseInt(id_becario, 10);
+    const intern = await getInternsById(internId);
+
+    if (!intern) {
+      return res.status(404).json({
+        success: false,
+        message: 'Becario no encontrado.',
+      });
+    }
+    const result = await getEventsInternById(eventId, internId);
+    if (!result) {
+      return res.status(404).json({
+        success: false,
+        message: 'El becario no está vinculado a este evento.',
+      });
+    }
     sendSuccess(res, result, 'Event_Interns process retrieved successfully');
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
bug: El endpoint GET /infoBecarios devolvía "success: true" aunque el intern_id proporcionado no existiera o no estuviera vinculado al evento, lo que causaba confusión al consumidor de la API.


fix: Se agregaron dos validaciones en el controller: primero, se verifica si el becario (intern_id) realmente existe en la base de datos; y segundo, se comprueba si dicho becario está vinculado al evento correspondiente (event_id). 
<img width="655" alt="Screenshot 2025-06-13 at 3 59 27 PM" src="https://github.com/user-attachments/assets/9afbae96-1f0f-470a-aeae-fb8c5e1087a2" />
<img width="898" alt="Screenshot 2025-06-13 at 3 59 45 PM" src="https://github.com/user-attachments/assets/fc767347-3f02-4366-b702-df8163647fc8" />
