### PR TITLE
fix(697): validaciones al crear usuario admin viejo desde createUser

### DIFF
--- a/src/interactors/adminInteractor.ts
+++ b/src/interactors/adminInteractor.ts
@@ -1,15 +1,16 @@
-import * as UserService from '../services/userService';
 import * as UserRoleService from '../services/userRoleService';
 import { createUserService } from '../services/adminService';
 import createUserRequest from '../dtos/createUserRequest';
 import genericUser from '../models/genericUser';
 
-const adminRole = 3;
+const adminRole = 1;
 
 export const createAdmin = async (studentData: createUserRequest) => {
   try {
-    const newStudent = await UserService.createUser(studentData);
-
+    const newStudent = await createUser({
+      ...studentData,
+      role_id: studentData.role_id ?? adminRole,
+    });
     if (!newStudent) {
       throw new Error('Error creating the admin');
     }
@@ -19,22 +20,51 @@ export const createAdmin = async (studentData: createUserRequest) => {
     if (!userRole) {
       throw new Error('Error creating the admin Role');
     }
+
     return newStudent;
   } catch (error) {
     console.error('Error in createAdmin interactor:', error);
+    if (error instanceof Error) {
+      throw error;
+    }
     throw new Error('Error creating the admin');
   }
 };
+
 export const createUser = async (userData: genericUser) => {
   try {
+    if (!userData.name || userData.name.trim().length < 2) {
+      throw new Error('El nombre debe tener al menos 2 caracteres válidos.');
+    }
+
+    if (!userData.lastname || userData.lastname.trim().length < 2) {
+      throw new Error('El apellido debe tener al menos 2 caracteres válidos.');
+    }
+
+    if (userData.mothername && userData.mothername.trim().length < 2) {
+      throw new Error('El nombre de la madre debe tener al menos 2 caracteres válidos.');
+    }
+
+    if (!/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/.test(userData.email)) {
+      throw new Error('El email no tiene un formato válido.');
+    }
+
+    if (!/^\d{7,10}$/.test(userData.phone)) {
+      throw new Error('El teléfono debe tener entre 7 y 10 dígitos numéricos.');
+    }
+
     const newUser = await createUserService(userData);
 
     if (!newUser) {
       throw new Error('Error creating the User');
     }
+
     return newUser;
   } catch (error) {
     console.error('Error in createUser interactor:', error);
+    if (error instanceof Error) {
+      throw error;
+    }
     throw new Error('Error creating the user');
   }
 };


### PR DESCRIPTION
bug: El endpoint POST /admin/old permitía crear usuarios con campos inválidos (nombre, apellido, email, etc.) ya que no se estaban aplicando validaciones. Y se le asignaba el role Id 3 cuando debía ser el 1. 

fix: Se agregaron validaciones manuales en la función createUser para asegurar que los campos requeridos tengan el formato y longitud adecuados. Además, createAdmin ahora utiliza createUser para aprovechar esas validaciones y establece role_id = 1
<img width="434" alt="Screenshot 2025-06-27 at 3 38 02 PM" src="https://github.com/user-attachments/assets/5538ed6e-153f-43fe-8d23-da3a7ec8f3ac" />
<img width="475" alt="Screenshot 2025-06-27 at 3 38 19 PM" src="https://github.com/user-attachments/assets/e5273881-e580-42f9-8403-52434b7f61b0" />
<img width="575" alt="Screenshot 2025-06-27 at 3 38 31 PM" src="https://github.com/user-attachments/assets/fb5cb6e2-4aff-45bf-8439-09be8e3e2b99" />
<img width="611" alt="Screenshot 2025-06-27 at 3 39 23 PM" src="https://github.com/user-attachments/assets/cbdcb3fb-ca91-4ac8-bba0-96213aa3b836" />
<img width="684" alt="Screenshot 2025-06-27 at 3 40 27 PM" src="https://github.com/user-attachments/assets/8e75bfca-04c4-4c3e-8586-5fdb34f3309a" />
