### PR TITLE
fix(#696): asigna correctamente el role_id=1 al crear un admin en POST /admin

### DIFF
--- a/src/interactors/adminInteractor.ts
+++ b/src/interactors/adminInteractor.ts
@@ -1,15 +1,16 @@
-import * as UserService from '../services/userService';
 import * as UserRoleService from '../services/userRoleService';
 import { createUserService } from '../services/adminService';
 import createUserRequest from '../dtos/createUserRequest';
 import genericUser from '../models/genericUser';
 
-const adminRole = 3;
+const adminRole = 1;
 
 export const createAdmin = async (studentData: createUserRequest) => {
   try {
-    const newStudent = await UserService.createUser(studentData);
-
+    const newStudent = await createUser({
+      ...studentData,
+      role_id: studentData.role_id ?? 1,
+    });
     if (!newStudent) {
       throw new Error('Error creating the admin');
     }
@@ -19,22 +20,54 @@ export const createAdmin = async (studentData: createUserRequest) => {
     if (!userRole) {
       throw new Error('Error creating the admin Role');
     }
+
     return newStudent;
   } catch (error) {
     console.error('Error in createAdmin interactor:', error);
+    if (error instanceof Error) {
+      throw error;
+    }
     throw new Error('Error creating the admin');
   }
 };
+
 export const createUser = async (userData: genericUser) => {
   try {
-    const newUser = await createUserService(userData);
+    if (!userData.name || userData.name.trim().length < 2) {
+      throw new Error('El nombre debe tener al menos 2 caracteres válidos.');
+    }
+
+    if (!userData.lastname || userData.lastname.trim().length < 2) {
+      throw new Error('El apellido debe tener al menos 2 caracteres válidos.');
+    }
+
+    if (userData.mothername && userData.mothername.trim().length < 2) {
+      throw new Error('El nombre de la madre debe tener al menos 2 caracteres válidos.');
+    }
+
+    if (!/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/.test(userData.email)) {
+      throw new Error('El email no tiene un formato válido.');
+    }
+
+    if (!/^\d{7,10}$/.test(userData.phone)) {
+      throw new Error('El teléfono debe tener entre 7 y 10 dígitos numéricos.');
+    }
+
+    const newUser = await createUserService({
+      ...userData,
+      role_id: userData.role_id ?? 1,
+    });
 
     if (!newUser) {
       throw new Error('Error creating the User');
     }
+
     return newUser;
   } catch (error) {
     console.error('Error in createUser interactor:', error);
+    if (error instanceof Error) {
+      throw error;
+    }
     throw new Error('Error creating the user');
   }
 };

--- a/src/models/userProfile.ts
+++ b/src/models/userProfile.ts
@@ -7,4 +7,5 @@ export interface userProfileInterface {
   password: string;
   mothername?: string;
   phone: string;
+  role_id: number;
 }


### PR DESCRIPTION
bug: El endpoint POST /admin no asignaba correctamente el campo role_id, lo que causaba que el nuevo usuario se insertara en la base de datos con un valor null en esa columna.

fix: Se propagó explícitamente el valor role_id = 1 en la cadena de funciones adminInteractor → createUser → createUserService → adminRepository, asegurando que el campo llegue correctamente hasta el insert en la tabla user_profile.
<img width="1270" alt="Screenshot 2025-06-30 at 3 23 26 PM" src="https://github.com/user-attachments/assets/febc7ad5-1d79-4d3c-8765-10fe481d831f" />
<img width="525" alt="Screenshot 2025-06-30 at 3 31 36 PM" src="https://github.com/user-attachments/assets/030d8087-ce02-49ec-93b1-7a6cc8ae71eb" />

Comentario adicional:
Este bug modifica el mismo archivo que la tarea #697, por lo que se trabajó sobre la implementación ya realizada en ese Pull Request. No se sobrescribió ninguna lógica previa, solo se añadió el role_id de forma controlada y compatible con el fix anterior.