### PR TITLE
 [19] El endpoint GET /internsOnEvent devuelve error incluso cuando el evento existe y tiene becarios registrados.

### DIFF
--- a/src/repositories/eventInternsRepository.ts
+++ b/src/repositories/eventInternsRepository.ts
@@ -9,7 +9,7 @@ export const getEventInterns = async (eventId: number) => {
     const listEventInterns = await db('events as e')
       .leftJoin(`${tableName} as ei`, 'ei.event_id', 'e.id')
       .leftJoin('interns as i', 'ei.intern_id', 'i.id')
-      .leftJoin('user_profile as up', 'i.user_profile_id', 'up.id')
+      .leftJoin('user_profile as up', 'i.id', 'up.id')
       .select(
         'e.id as id_events',
         'e.*',


### PR DESCRIPTION
# Bug
El endpoint para obtener a los becarios relacionados a determinado evento responde con código de error incluso si el evento tiene becarios asignados y existe, esto evita obtener los datos válidos incluso si existen dentro de la base de datos
![image](https://github.com/user-attachments/assets/3d8280a2-07f6-4de8-a932-bd6894d1aaca)

# Fix
Se verificó el flujo de código a través de las capas del backend y se encontró el problema en la comunicación para la base de datos, ya que en la consulta SQL se hacía referencia a una columna que no está presente en la tabla UserProfile. Se analizó la estructura de la base de datos con diagramas de DBeaver y se reemplazó el atributo solicitado anteriormente por la FK que relaciona la tabla Interns con UserProfile.
```tsx
.leftJoin('user_profile as up', 'i.id', 'up.id')
```

# Resultados
Las consultas ahora devuelven los datos correspondientes, devolviendo una lista de los becarios asociados para cada evento o una lista vacía si el evento no tiene becarios asociados
![image](https://github.com/user-attachments/assets/4e800da5-6101-4898-8f97-1fc02c1f5a4a)
![image](https://github.com/user-attachments/assets/380990c4-8996-4d82-8bd1-9fa4ceaffbdf)
![image](https://github.com/user-attachments/assets/ae90f3d3-6272-48bb-a2c7-0d5e2cd15abe)

>[!Warning]
>Se permite hacer consultas con IDs inválidos, tales como letras, caracteres especiales y IDs de eventos no existentes. Los eventos no existentes retornan una lista vacía, por lo que se cumple con los requisitos propuestos por el bug report, sin embargo se recomienda al equipo QA inspeccionar más a fondo este endpoint para reportar los bugs correspondientes.
![image](https://github.com/user-attachments/assets/f9298f53-0416-4afe-b50b-9882cac82cfd)