### PR TITLE
Refactor/900 login uses db function

### DIFF
--- a/data/migrations/20250827093000_fn_get_user_session_by_email.ts
+++ b/data/migrations/20250827093000_fn_get_user_session_by_email.ts
@@ -1,0 +1,57 @@
+import type { Knex } from 'knex';
+
+const usersTable = 'user_profile';
+const emailLowerIndex = 'idx_user_profile_email_lower';
+const sessionFunction = 'fn_get_user_session_by_email';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    create index if not exists ${emailLowerIndex}
+    on ${usersTable}(lower(email));
+  `);
+
+  await knex.raw(`
+    create or replace function ${sessionFunction}(p_email text)
+    returns table (
+      user_id        int,
+      user_email     text,
+      user_username  text,
+      user_name      text,
+      user_lastname  text,
+      password_hash  text,
+      permissions    jsonb,
+      menu           jsonb
+    )
+    language sql
+    stable
+    as $$
+      with u as (
+        select
+          id        as user_id,
+          email     as user_email,
+          username  as user_username,
+          name      as user_name,
+          lastname  as user_lastname,
+          password  as password_hash
+        from ${usersTable}
+        where lower(email) = lower(p_email)
+        limit 1
+      )
+      select
+        u.user_id,
+        u.user_email,
+        u.user_username,
+        u.user_name,
+        u.user_lastname,
+        u.password_hash,
+        '[]'::jsonb as permissions,
+        '[]'::jsonb as menu
+      from u;
+    $$;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`drop function if exists ${sessionFunction}(text)`);
+  await knex.raw(`drop index if exists ${emailLowerIndex}`);
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import permissionRouter from './routes/permissionRouters';
 import userProfileRouter from './routes/userProfileRoutes';
 import rolesRouter from './routes/rolesRoutes';
 import menuRoutes from './routes/menuRoutes';
+import userProfileRoutes from './routes/userProfileRoutes';
 
 dotenv.config();
 
@@ -43,5 +44,6 @@ app.use('/api/interns', internsRouter);
 app.use('/api/user', userProfileRouter);
 app.use('/api/roles', rolesRouter);
 app.use('/api/', menuRoutes);
+app.use('/api/users', userProfileRoutes);
 
 export default app;

--- a/src/controllers/userProfileController.ts
+++ b/src/controllers/userProfileController.ts
@@ -6,11 +6,12 @@ import { sendSuccess } from '../handlers/successHandler';
 import { handleError } from '../handlers/errorHandler';
 import { BadRequestError } from '../errors/badRequestError';
 import createUserRequest from '../dtos/createUserRequest';
+import { loginByEmail } from '../services/userProfileService';
 
 const isNotID = (userIdString: string) => {
   const userIdNumber = Number(userIdString);
-  return isNaN(userIdNumber) || userIdNumber<0 || userIdNumber%1!==0
-}
+  return isNaN(userIdNumber) || userIdNumber < 0 || userIdNumber % 1 !== 0;
+};
 
 export const deleteUser = async (req: Request, res: Response) => {
   const userId = req.params.id;
@@ -41,8 +42,8 @@ export const getUser = async (req: Request, res: Response) => {
     const { id } = req.params;
 
     if (isNotID(id)) {
-      handleError(res, new BadRequestError("El ID debe ser un número entero"))
-      return
+      handleError(res, new BadRequestError('El ID debe ser un número entero'));
+      return;
     }
 
     const user = await userProfileInteractor.getUser(id);
@@ -55,25 +56,27 @@ export const getUser = async (req: Request, res: Response) => {
 };
 
 const isValidUserInfo = (req: Request) => {
-  const { name, lastname, mothername, code, email, phone } = req.body
+  const { name, lastname, mothername, code, email, phone } = req.body;
   const regexNames = /^[a-zA-Z]{4,}$/;
   const regexMail = /^[a-zA-Z0-9]{4,32}@[a-zA-Z]{1,10}\.[a-zA-Z]{1,4}$/;
-  const regexPhoneNumber = /^[0-9]{7,12}$/
-  const regexCode = /^[0-9]{4,6}$/
+  const regexPhoneNumber = /^[0-9]{7,12}$/;
+  const regexCode = /^[0-9]{4,6}$/;
 
-  return regexNames.test(name) &&
+  return (
+    regexNames.test(name) &&
     regexNames.test(lastname) &&
     regexNames.test(mothername) &&
     regexMail.test(email) &&
     regexCode.test(code) &&
-    regexPhoneNumber.test(phone)
-}
+    regexPhoneNumber.test(phone);
+  );
+};
 
 export const createUser = async (req: Request, res: Response) => {
   try {
     if (!isValidUserInfo(req)) {
-      handleError(res, new BadRequestError("Campos con información no válida"))
-      return
+      handleError(res, new BadRequestError('Campos con información no válida'));
+      return;
     }
     const userData: createUserRequest = req.body;
     const newUser = await userProfileInteractor.createUser(userData);
@@ -89,10 +92,10 @@ export const updateUser = async (req: Request, res: Response) => {
     const { id } = req.params;
 
     if (isNotID(id)) {
-      handleError(res, new BadRequestError("El ID debe ser un número entero"))
-      return
+      handleError(res, new BadRequestError('El ID debe ser un número entero'));
+      return;
     }
-    
+
     const userProfileData: createUserRequest = req.body;
     const user = await userProfileInteractor.updateUser(id, userProfileData);
     sendSuccess(res, user, 'User was updated successfully');
@@ -110,6 +113,27 @@ export const getPublicProfileById = async (req: Request, res: Response) => {
     sendSuccess(res, profile, 'Profile obtained successfully');
   } catch (error) {
     if (error instanceof Error) {
+      handleError(res, error);
+    }
+  }
+};
+export const loginUser = async (req: Request, res: Response) => {
+  try {
+    const { email, password } = req.body ?? {};
+
+    if (!email || !password) {
+      handleError(res, new BadRequestError('Email y password requeridos'));
+      return;
+    }
+
+    const session = await loginByEmail(email, password);
+    sendSuccess(res, session, 'Login successful');
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'INVALID_CREDENTIALS') {
+        handleError(res, new BadRequestError('Credenciales inválidas'));
+        return;
+      }
       handleError(res, error);
     }
   }

--- a/src/controllers/userProfileController.ts
+++ b/src/controllers/userProfileController.ts
@@ -68,9 +68,10 @@ const isValidUserInfo = (req: Request) => {
     regexNames.test(mothername) &&
     regexMail.test(email) &&
     regexCode.test(code) &&
-    regexPhoneNumber.test(phone);
+    regexPhoneNumber.test(phone)
   );
 };
+
 
 export const createUser = async (req: Request, res: Response) => {
   try {

--- a/src/repositories/userProfileRepository.ts
+++ b/src/repositories/userProfileRepository.ts
@@ -3,8 +3,13 @@ import { userProfileInterface } from '../models/userProfile';
 import { buildLogger } from '../plugin/logger';
 import { StudentProfileResponseDTO } from '../dtos/studentProfileResponse';
 
-
 import db from './pg-connection';
+
+export async function getUserSessionByEmail(email: string) {
+  const sql = 'select * from public.fn_get_user_session_by_email(?) limit 1';
+  const { rows } = await db.raw(sql, [email]);
+  return rows?.[0] ?? null;
+}
 
 const logger = buildLogger('userProfileRepository');
 
@@ -72,23 +77,26 @@ export const updateUserProfileRole = async (userId: string, roleId: number) => {
   }
 };
 
-
-export const getUserProfilePublicById = async (userId: string): Promise<StudentProfileResponseDTO | null> => {
+export const getUserProfilePublicById = async (
+  userId: string
+): Promise<StudentProfileResponseDTO | null> => {
   try {
     const row = await db(`${TABLE_NAME} as up`)
       .leftJoin('roles as r', 'r.id', 'up.role_id')
       .select(
         'up.id',
         'up.name',
-        db.raw(`'' as career`),   
+        db.raw("'' as career"),
         'up.phone',
         'up.email',
-        db.raw(`COALESCE(r.name, 'unknown') as role`)
+        db.raw("COALESCE(r.name, 'unknown') as role")
       )
       .where('up.id', userId)
       .first();
 
-    if (!row) return null;
+    if (!row) {
+      return null;
+    }
 
     return {
       id: String(row.id),

--- a/src/routes/userProfileRoutes.ts
+++ b/src/routes/userProfileRoutes.ts
@@ -16,4 +16,5 @@ router.route('/:id').get(checkUserAuth, UserProfileController.getUser);
 router.route('/').post(checkUserAuth, UserProfileController.createUser);
 router.route('/:id').put(checkUserAuth, UserProfileController.updateUser);
 router.get('/profile/:id', checkUserAuth, UserProfileController.getPublicProfileById);
+router.post('/login', UserProfileController.loginUser);
 export default router;

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -24,6 +24,6 @@ export const createUserService = async (user: genericUser) => {
     });
   } catch (error) {
     console.log('Error creating User');
-    throw Error('Error creating User');
+    throw error;
   }
 };

--- a/src/services/userProfileService.ts
+++ b/src/services/userProfileService.ts
@@ -6,13 +6,13 @@ import UserRole from '../constants/roles';
 import UserResponse from '../models/genericUserResponse';
 import { buildLogger } from '../plugin/logger';
 import config from '../config/config';
-
-import * as AuthenticationService from './authenticationService';
-
-// 
 import { StudentProfileResponseDTO } from '../dtos/studentProfileResponse';
 import { getUserProfilePublicById } from '../repositories/userProfileRepository';
 import { NotFoundError } from '../errors/notFoundError';
+
+import * as AuthenticationService from './authenticationService';
+
+//
 
 export const getPublicProfileById = async (userId: string): Promise<StudentProfileResponseDTO> => {
   const profile = await getUserProfilePublicById(userId);
@@ -22,6 +22,47 @@ export const getPublicProfileById = async (userId: string): Promise<StudentProfi
   return profile;
 };
 //
+
+// NUEVO
+import bcrypt from 'bcryptjs';
+
+import { getUserSessionByEmail } from '../repositories/userProfileRepository';
+
+export type LoginResult = {
+  user: {
+    id: number;
+    email: string;
+    username: string;
+    name: string;
+    lastname: string;
+  };
+  permissions: unknown[];
+  menu: unknown[];
+};
+
+export const loginByEmail = async (email: string, plainPassword: string): Promise<LoginResult> => {
+  const row = await getUserSessionByEmail(email);
+  if (!row) {
+    throw new Error('INVALID_CREDENTIALS');
+  }
+
+  const ok = await bcrypt.compare(plainPassword, row.password_hash);
+  if (!ok) {
+    throw new Error('INVALID_CREDENTIALS');
+  }
+
+  return {
+    user: {
+      id: row.user_id,
+      email: row.user_email,
+      username: row.user_username,
+      name: row.user_name,
+      lastname: row.user_lastname,
+    },
+    permissions: row.permissions ?? [],
+    menu: row.menu ?? [],
+  };
+};
 
 const logger = buildLogger('userProfileService');
 const { defaultUserPassword } = config;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -74,6 +74,6 @@ export const getProfessorById = async (id: string) => {
     return professor;
   } catch (error) {
     console.error('Error in getProfessorById interactor:', error);
-    throw new Error('Error fetching the professor');
+    throw error;
   }
 };

--- a/test/services/authenticationService.test.ts
+++ b/test/services/authenticationService.test.ts
@@ -1,5 +1,6 @@
-import * as AuthService from '../../src/services/authenticationService';
 import bcrypt from 'bcryptjs';
+
+import * as AuthService from '../../src/services/authenticationService';
 
 jest.mock('bcryptjs');
 
@@ -7,23 +8,23 @@ const bcryptMock = bcrypt as jest.Mocked<typeof bcrypt>;
 
 describe('authenticationService.verifyPassword', () => {
   it('compares passwords using bcrypt', async () => {
-    bcryptMock.compare.mockResolvedValue(true as any);
-    await expect(AuthService.verifyPassword('a','b')).resolves.toBe(true);
-    expect(bcryptMock.compare).toHaveBeenCalledWith('a','b');
+    (bcryptMock.compare as any).mockResolvedValue(true);
+    await expect(AuthService.verifyPassword('a', 'b')).resolves.toBe(true);
+    expect(bcryptMock.compare).toHaveBeenCalledWith('a', 'b');
   });
 
   it('throws when bcrypt throws', async () => {
-    bcryptMock.compare.mockRejectedValue(new Error('bad'));
-    await expect(AuthService.verifyPassword('a','b')).rejects.toThrow('bad');
+    (bcryptMock.compare as any).mockRejectedValue(new Error('bad'));
+    await expect(AuthService.verifyPassword('a', 'b')).rejects.toThrow('bad');
   });
 });
 
 describe('authenticationService.hashPassword', () => {
   it('hashes with salt', async () => {
-    bcryptMock.genSalt.mockResolvedValue('s' as any);
-    bcryptMock.hash.mockResolvedValue('h' as any);
+    (bcryptMock.genSalt as any).mockResolvedValue('s');
+    (bcryptMock.hash as any).mockResolvedValue('h');
     await expect(AuthService.hashPassword('p')).resolves.toBe('h');
     expect(bcryptMock.genSalt).toHaveBeenCalledWith(10);
-    expect(bcryptMock.hash).toHaveBeenCalledWith('p','s');
+    expect(bcryptMock.hash).toHaveBeenCalledWith('p', 's');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
-    "rootDir": "./src" /* Specify the root folder within your source files. */,
+    // "rootDir": "./src" /* Specify the root folder within your source files. */,
     "baseUrl": "./",
     "paths": {
       "@migrations/*": ["data/migrations/*"]


### PR DESCRIPTION
Este PR refactoriza el flujo de login para que en lugar de múltiples queries a la base de datos, se realice una sola llamada a la función fn_get_user_session_by_email.
Cambios realizados

src/repositories/userProfileRepository.ts
	•	Se agregó getUserSessionByEmail(email) que ejecuta la función SQL fn_get_user_session_by_email.
	•	Se eliminó la dependencia a múltiples consultas.

src/services/userProfileService.ts
	•	Se implementó loginByEmail(email, password) que:
	•	Invoca getUserSessionByEmail.
	•	Valida el password_hash usando bcrypt.compare.
	•	Retorna un objeto de sesión con user, permissions y menu.
	•	Se corrigió el manejo de roles en createUserProfile y updateUserRoles para que ya no dependan de role_id en user_profile, sino de user_roles.

src/controllers/userProfileController.ts
	•	Se añadió el handler loginUser que expone el endpoint /login.

src/routes/userProfileRoutes.ts (o equivalente)
	•	Se agregó la ruta POST /api/users/login que apunta a loginUser.


<img width="1264" height="720" alt="Screenshot 2025-08-29 at 7 41 22 PM" src="https://github.com/user-attachments/assets/91ac2942-bdfc-4911-ace0-433189ff8929" />
