### PR TITLE
fix(backend): clear message for project_name when entering more than 255 characters

### DIFF
--- a/src/middlewares/schemas/updateGraduationProcessSchema.ts
+++ b/src/middlewares/schemas/updateGraduationProcessSchema.ts
@@ -10,7 +10,10 @@ const updateGraduationProcessSchema = Joi.object({
   modality_id: Joi.number().integer().optional().messages({
     'number.base': 'Modality ID must be an integer',
   }),
-  project_name: Joi.string().optional(),
+  project_name: Joi.string().max(255).optional().messages({
+    'string.base': 'Project name must be a string',
+    'string.max': 'Project name cannot exceed 255 characters',
+  }),
   period: Joi.string().optional(),
   date_seminar_enrollment: Joi.date().allow(null).optional().messages({
     'date.base': 'Date of seminar enrollment must be a valid date or null',


### PR DESCRIPTION
## Contexto

Al actualizar un Proceso de Graduación con project_name > 255 chars vía PUT /api/graduation/:id, el backend rechazaba la solicitud pero no entregaba un mensaje de error específico. Esto dejaba al usuario sin guía para corregir el input.

## ¿Qué se cambió?

Se agrega validación de longitud en el schema para `project_name` y mensajes explícitos de error, alineados con el formato de errores existente.

```ts
project_name: Joi.string().max(255).optional().messages({
  'string.base': 'Project name must be a string',
  'string.max': 'Project name cannot exceed 255 characters',
}),
```

---

## Pruebas de funcionamiento:

Se acepta si esta en el rango
<img width="1198" height="926" alt="Screenshot 2025-10-03 151808" src="https://github.com/user-attachments/assets/7ef6c717-1894-4d40-ad67-d9be34adb13a" />

Se muestra el mensaje de rechazo
<img width="1178" height="604" alt="Screenshot 2025-10-03 151743" src="https://github.com/user-attachments/assets/62829911-9722-4b01-adf1-1c2f2cca3926" />

Tarea: https://linear.app/upb/issue/UPB-28/backend-implementar-validacion-de-longitud-maxima-y-mensaje-de-error