### PR TITLE
Validación de project_name en actualización de Proceso de Graduación

### DIFF
--- a/src/middlewares/schemas/updateGraduationProcessSchema.ts
+++ b/src/middlewares/schemas/updateGraduationProcessSchema.ts
@@ -10,8 +10,10 @@ const updateGraduationProcessSchema = Joi.object({
   modality_id: Joi.number().integer().optional().messages({
     'number.base': 'Modality ID must be an integer',
   }),
-  project_name: Joi.string().max(255).optional().messages({
+  project_name: Joi.string().trim().min(5).max(255).optional().messages({
     'string.base': 'Project name must be a string',
+    'string.empty': 'Project name is required and cannot be empty',
+    'string.min': 'Project name must have at least 5 characters',
     'string.max': 'Project name cannot exceed 255 characters',
   }),
   period: Joi.string().optional(),

--- a/src/middlewares/schemas/updateGraduationProcessSchema.ts
+++ b/src/middlewares/schemas/updateGraduationProcessSchema.ts
@@ -10,7 +10,10 @@ const updateGraduationProcessSchema = Joi.object({
   modality_id: Joi.number().integer().optional().messages({
     'number.base': 'Modality ID must be an integer',
   }),
-  project_name: Joi.string().optional(),
+  project_name: Joi.string().max(255).optional().messages({
+    'string.base': 'Project name must be a string',
+    'string.max': 'Project name cannot exceed 255 characters',
+  }),
   period: Joi.string().optional(),
   date_seminar_enrollment: Joi.date().allow(null).optional().messages({
     'date.base': 'Date of seminar enrollment must be a valid date or null',


### PR DESCRIPTION
## Descripción

Se mejoró la validación del campo project_name en el endpoint PUT /graduation/{id} para evitar que se guarden valores inválidos compuestos únicamente por espacios en blanco.

Anteriormente, el backend aceptaba un nombre de proyecto vacío (" "), comprometiendo la integridad de los datos. Ahora se rechaza correctamente con un mensaje de error claro.

## Cambios realizados

Se actualizó el schema de validación (updateGraduationProcessSchema) para:

Aplicar .trim() y .min(5) en project_name.

Rechazar cadenas vacías o de solo espacios.

Mejorar mensajes de error para guiar al usuario.

```ts
  project_name: Joi.string().trim().min(5).max(255).optional().messages({
    'string.base': 'Project name must be a string',
    'string.empty': 'Project name is required and cannot be empty',
    'string.min': 'Project name must have at least 5 characters',
    'string.max': 'Project name cannot exceed 255 characters',
  }),
```

---

Prueba de funcionamiento:

Cuando se envia vacio
<img width="1206" height="748" alt="image" src="https://github.com/user-attachments/assets/d3a3146b-7449-4f88-aaec-d9d84351cfc6" />

Cuando se envia con solo espacios
<img width="1232" height="762" alt="image" src="https://github.com/user-attachments/assets/b159683a-959f-4e6c-89d3-e66c77b643bc" />

Cuando se envia con menos de 5 caracteres
<img width="1212" height="593" alt="image" src="https://github.com/user-attachments/assets/7b12be5d-9515-4a55-8e35-07e350f8f385" />

Cuando se envia dentro de los parametros
<img width="1209" height="827" alt="image" src="https://github.com/user-attachments/assets/da60d2df-870b-4a44-81cf-b168ca9a8f4c" />

Tarea: https://linear.app/upb/issue/UPB-27/backend-mejorar-la-validacion-del-campo-project-name-en-el-endpoint-de