### PR TITLE
Fix: Validar campo period en creación de procesos de graduación (formato YYYY-M/MM, meses 1–12) y que no se permitan caracteres especiales

### DIFF
--- a/src/middlewares/schemas/createGraduationProcessSchema.ts
+++ b/src/middlewares/schemas/createGraduationProcessSchema.ts
@@ -12,9 +12,16 @@ const createGraduationProcessSchema = Joi.object({
   project_name: Joi.string().required().messages({
     'any.required': 'Project name is required',
   }),
-  period: Joi.string().required().messages({
-    'any.required': 'Period is required',
-  }),
+  period: Joi.string()
+    .trim()
+    .pattern(/^\d{4}-(0?[1-9]|1[0-2])$/)
+    .required()
+    .messages({
+      'any.required': 'Period is required',
+      'string.empty': 'Period is required and cannot be empty',
+      'string.pattern.base':
+        'Invalid period format. Use YYYY-M or YYYY-MM (e.g., 2025-1, 2025-09). Special characters are not allowed.',
+    }),
   stage_id: Joi.number().integer().required().messages({
     'number.base': 'Stage ID must be an integer',
     'any.required': 'Stage ID is required',

--- a/src/middlewares/schemas/updateGraduationProcessSchema.ts
+++ b/src/middlewares/schemas/updateGraduationProcessSchema.ts
@@ -10,8 +10,10 @@ const updateGraduationProcessSchema = Joi.object({
   modality_id: Joi.number().integer().optional().messages({
     'number.base': 'Modality ID must be an integer',
   }),
-  project_name: Joi.string().max(255).optional().messages({
+  project_name: Joi.string().trim().min(5).max(255).optional().messages({
     'string.base': 'Project name must be a string',
+    'string.empty': 'Project name is required and cannot be empty',
+    'string.min': 'Project name must have at least 5 characters',
     'string.max': 'Project name cannot exceed 255 characters',
   }),
   period: Joi.string().optional(),

--- a/src/middlewares/schemas/updateGraduationProcessSchema.ts
+++ b/src/middlewares/schemas/updateGraduationProcessSchema.ts
@@ -10,7 +10,10 @@ const updateGraduationProcessSchema = Joi.object({
   modality_id: Joi.number().integer().optional().messages({
     'number.base': 'Modality ID must be an integer',
   }),
-  project_name: Joi.string().optional(),
+  project_name: Joi.string().max(255).optional().messages({
+    'string.base': 'Project name must be a string',
+    'string.max': 'Project name cannot exceed 255 characters',
+  }),
   period: Joi.string().optional(),
   date_seminar_enrollment: Joi.date().allow(null).optional().messages({
     'date.base': 'Date of seminar enrollment must be a valid date or null',


### PR DESCRIPTION
## Descripción

Este PR corrige la validación del campo period en el endpoint POST /graduation:

Se implementa validación mediante regex para aceptar únicamente los formatos:

YYYY-M → ej. 2025-1

YYYY-MM → ej. 2025-09

Se permiten únicamente meses válidos (1–12).

Se rechazan caracteres especiales o formatos inválidos.

En caso de error, el backend responde con HTTP 400 Bad Request y un mensaje claro indicando las restricciones del campo.

## Cambios realizados

- Se actualizó el schema de validación (createGraduationProcessSchema) para:
 
- Aplicar .trim() en el campo period para eliminar espacios en blanco.

- Restringir el formato de period a YYYY-M o YYYY-MM, aceptando solo meses válidos (1–12).
 
- Rechazar valores con caracteres especiales o formatos incorrectos (ej: 2025/09, !!!, 2025-13).
 
- Hacer que el campo sea obligatorio en POST.
 
- Mejorar los mensajes de error para guiar al usuario con ejemplos claros.

```ts
period: Joi.string()
  .trim()
  .pattern(/^\d{4}-(0?[1-9]|1[0-2])$/)
  .required()
  .messages({
    'any.required': 'Period is required',
    'string.empty': 'Period is required and cannot be empty',
    'string.pattern.base':
      'Invalid period format. Use YYYY-M or YYYY-MM (e.g., 2025-1, 2025-09). Special characters are not allowed.',
  }),
```

---

Prueba de funcionamiento:

Cuando no se pone el campo period
<img width="1211" height="642" alt="Screenshot 2025-10-04 003125" src="https://github.com/user-attachments/assets/92510864-cac8-4ffa-afdf-f73da88de5ed" />

Cuando el campo period esta vacio
<img width="1217" height="631" alt="Screenshot 2025-10-04 003112" src="https://github.com/user-attachments/assets/b0576252-63c2-406f-98b2-0dd9652dcde8" />

Cuando el campo period tiene caracteres especiales
<img width="1186" height="688" alt="Screenshot 2025-10-04 003701" src="https://github.com/user-attachments/assets/66bbbbc2-9eeb-4200-a28a-26b416a84f2c" />

Cuando se envia correctamente
<img width="1235" height="873" alt="Screenshot 2025-10-04 003423" src="https://github.com/user-attachments/assets/4cd6cd48-4d93-43db-a723-5e8c5460865b" />
