### PR TITLE
fix(validacion): campo period ahora tiene un formato de  PrimeroYYYY o SegundoYYYY

### DIFF
--- a/src/middlewares/schemas/createGraduationProcessSchema.ts
+++ b/src/middlewares/schemas/createGraduationProcessSchema.ts
@@ -14,13 +14,13 @@ const createGraduationProcessSchema = Joi.object({
   }),
   period: Joi.string()
     .trim()
-    .pattern(/^\d{4}-(0?[1-9]|1[0-2])$/)
+    .pattern(/^(Primero|Segundo)[-\s]?\d{4}$/)
     .required()
     .messages({
       'any.required': 'Period is required',
       'string.empty': 'Period is required and cannot be empty',
       'string.pattern.base':
-        'Invalid period format. Use YYYY-M or YYYY-MM (e.g., 2025-1, 2025-09). Special characters are not allowed.',
+        'Invalid period format. Use PrimeroYYYY or SegundoYYYY (e.g., Primero2025, Segundo2025).',
     }),
   stage_id: Joi.number().integer().required().messages({
     'number.base': 'Stage ID must be an integer',


### PR DESCRIPTION
## Contexto
El formulario de creación de Procesos de Graduación estaba enviando el campo period con el formato "Primero2025" o "Segundo2025", pero la validación del backend con Joi solo aceptaba el formato "YYYY-MM".

## Cambios realizados

Se actualizó la validación de period en Joi para aceptar los nuevos formatos:

PrimeroYYYY

SegundoYYYY

con espacio o guion opcional (por ejemplo: Primero-2025, Segundo 2025)

Se mejoró el mensaje de error para brindar una retroalimentación más clara al usuario.

Resultado
Ahora el backend acepta y valida correctamente el nuevo formato de período enviado desde el frontend.

```typescript
period: Joi.string()
    .trim()
    .pattern(/^(Primero|Segundo)[-\s]?\d{4}$/)
    .required()
    .messages({
      'any.required': 'Period is required',
      'string.empty': 'Period is required and cannot be empty',
      'string.pattern.base':
        'Invalid period format. Use PrimeroYYYY or SegundoYYYY (e.g., Primero2025, Segundo2025).',
    }),
```

## Pruebas de Funcionamiento:

Creacion del Proceso (frontend):
<img width="1366" height="1053" alt="Screenshot 2025-10-16 180148" src="https://github.com/user-attachments/assets/cc6b72ec-f850-4127-9a2d-2d03605e06ef" />

Payload enviado:
<img width="717" height="203" alt="Screenshot 2025-10-16 180311" src="https://github.com/user-attachments/assets/bb9e374c-e524-4e5a-8751-8809d4a772d9" />

Se guarda en la base de datos:
<img width="894" height="36" alt="Screenshot 2025-10-16 180336" src="https://github.com/user-attachments/assets/870acf19-0176-46be-8893-93b75ce7bff7" />
