### PR TITLE
Título: Validación estricta de :id en endpoint Get /students/:id

### DIFF
--- a/src/routes/studentRoutes.ts
+++ b/src/routes/studentRoutes.ts
@@ -7,6 +7,7 @@ import { createStudentSchema } from '../middlewares/schemas/createUserSchema';
 import { validateParams } from '../middlewares/validateParamsMiddleware';
 import { studentCodeSchema } from '../middlewares/schemas/studenCodeSchema';
 import { studentSquema } from '../middlewares/schemas/updateStudentSquema';
+import { paramIdSchema } from '../middlewares/schemas/paramIdSchema';
 
 const router = Router();
 
@@ -22,8 +23,12 @@ router
 
 router.route('/:id').delete(checkUserAuth, StudentController.deleteStudent);
 
-router.route('/:id').get(checkUserAuth, StudentController.getStudent);
+router
+  .route('/:id')
+  .get(checkUserAuth, validateParams(paramIdSchema), StudentController.getStudent);
 
-router.route('/:id').put(checkUserAuth, validateBody(studentSquema), StudentController.updateStudent);
+router
+  .route('/:id')
+  .put(checkUserAuth, validateBody(studentSquema), StudentController.updateStudent);
 
 export default router;


### PR DESCRIPTION
## Contexto
El endpoint `GET /students/:id` aceptaba valores como 7textoextra o 1holi. Esto permitía entradas con información adicional no deseada.

## Cambios

Se agregó validateParams(paramIdSchema) del archivo `src/schemas/paramIdSchema.ts`, a la ruta:

GET /students/:id

```typescript
router
  .route('/:id')
  .get(checkUserAuth, validateParams(paramIdSchema), StudentController.getStudent);
```

## Resultado

Antes, si se ponía "1holi", se retornaba la información del estudiante:

<img width="1236" height="795" alt="Screenshot 2025-10-17 165923" src="https://github.com/user-attachments/assets/bae01574-e1ab-4e0d-a0f6-437be78f8c09" />

Ahora, si el id contiene información extra (por ej. 1holi), ahora se devuelve 400 con un mensaje de validación claro.

<img width="764" height="412" alt="Screenshot 2025-10-17 165958" src="https://github.com/user-attachments/assets/033d903d-e199-46f8-8d5d-6042c67cf541" />

Si el id es válido (p. ej. 1), el flujo original no cambia y se retorna la información del estudiante.
<img width="1016" height="790" alt="Screenshot 2025-10-17 170012" src="https://github.com/user-attachments/assets/c1679d45-d1b0-4149-8216-7041f12ed55c" />

Tarea: https://linear.app/upb/issue/UPB-165/backend-fix-endpoint-get-student-by-id-permite-introduccion-de-ids