### PR TITLE
fix(student): manejar correctamente error 404 al buscar estudiante inexistente

### DIFF
--- a/src/interactors/studentInteractor.ts
+++ b/src/interactors/studentInteractor.ts
@@ -117,7 +117,10 @@ export const getStudent = async (studentId: number) => {
     return student;
   } catch (error) {
     console.error('Error getting student:', error);
-    throw new Error('Error getting student');
+    if (error instanceof NotFoundError || error instanceof HttpError) {
+      throw error;
+    }
+    throw new HttpError(500, 'Unexpected error retrieving student');
   }
 };
 
@@ -140,7 +143,9 @@ export const updateStudent = async (studentId: number, studentData: createUserRe
     return updatedStudent;
   } catch (error) {
     console.error('Error updating student:', error);
-    if (error instanceof HttpError) throw error;
+    if (error instanceof HttpError) {
+      throw error;
+    }
     throw new Error('Error updating student');
   }
 };

--- a/src/routes/studentRoutes.ts
+++ b/src/routes/studentRoutes.ts
@@ -7,6 +7,7 @@ import { createStudentSchema } from '../middlewares/schemas/createUserSchema';
 import { validateParams } from '../middlewares/validateParamsMiddleware';
 import { studentCodeSchema } from '../middlewares/schemas/studenCodeSchema';
 import { studentSquema } from '../middlewares/schemas/updateStudentSquema';
+import { paramIdSchema } from '../middlewares/schemas/paramIdSchema';
 
 const router = Router();
 
@@ -22,8 +23,12 @@ router
 
 router.route('/:id').delete(checkUserAuth, StudentController.deleteStudent);
 
-router.route('/:id').get(checkUserAuth, StudentController.getStudent);
+router
+  .route('/:id')
+  .get(checkUserAuth, validateParams(paramIdSchema), StudentController.getStudent);
 
-router.route('/:id').put(checkUserAuth, validateBody(studentSquema), StudentController.updateStudent);
+router
+  .route('/:id')
+  .put(checkUserAuth, validateBody(studentSquema), StudentController.updateStudent);
 
 export default router;


### PR DESCRIPTION
## Contexto

Al realizar una solicitud al endpoint GET /api/students/:id con un ID inexistente, el backend retornaba un 500 Internal Server Error genérico.
Esto dificultaba identificar la causa real del error.

## Cambios realizados

Se actualizó el método getStudent en src/interactors/studentInteractor.ts para manejar correctamente el caso de un ID inexistente.

Si el estudiante no se encuentra, ahora se lanza un NotFoundError('Student not found').

En el bloque catch, se agregó una validación que permite pasar los errores esperados (NotFoundError o HttpError) y solo transforma en error 500 los casos inesperados.

Se mejoró el mensaje de error interno a "Unexpected error retrieving student" para mayor claridad.

Resultado

ID inexistente → responde con 404 y mensaje claro:

<img width="776" height="461" alt="Screenshot 2025-10-19 164151" src="https://github.com/user-attachments/assets/3b2293e2-e25d-416b-92e9-410ba9fbe1a4" />

 ID válido → flujo normal, devuelve 200 con los datos del estudiante.

Errores inesperados → responden con 500 controlado y mensaje informativo.

```typescript
if (error instanceof NotFoundError || error instanceof HttpError) {
  throw error;
}
throw new HttpError(500, 'Unexpected error retrieving student');
```

---

Tarea: https://linear.app/upb/issue/UPB-164/backend-fix-endpoint-get-student-by-id-retorna-mensaje-de-error