### PR TITLE
Fix: Endpoint para obtener tutores disponibles en fase de asignación

### DIFF
--- a/src/controllers/graduationController.ts
+++ b/src/controllers/graduationController.ts
@@ -1,13 +1,12 @@
 import { Request, Response } from 'express';
-
 import * as GraduationProcessInteractor from '../interactors/graduationInteractor';
+import * as ProfessorRepository from '../repositories/professorRepository';
 import createGraduationProcessRequest from '../dtos/createGraduationProcessRequest';
 import { handleError } from '../handlers/errorHandler';
 import { sendCreated, sendSuccess } from '../handlers/successHandler';
 
 export const getGraduationProcessByIdController = async (req: Request, res: Response) => {
   const processId = parseInt(req.params.id);
-
   try {
     const graduationProcess = await GraduationProcessInteractor.getGraduationProcessById(processId);
     if (!graduationProcess) {
@@ -22,7 +21,6 @@ export const getGraduationProcessByIdController = async (req: Request, res: Resp
 export const updateGraduationProcessController = async (req: Request, res: Response) => {
   const processId = parseInt(req.params.id);
   const updatedData = req.body;
-
   try {
     const updatedGraduationProcess = await GraduationProcessInteractor.updateGraduationProcess(
       processId,
@@ -41,7 +39,6 @@ export const updateGraduationProcessController = async (req: Request, res: Respo
 
 export const createGraduationProcessController = async (req: Request, res: Response) => {
   const graduationProcess: createGraduationProcessRequest = req.body;
-
   try {
     const newGraduationProcess =
       await GraduationProcessInteractor.createGraduationProcess(graduationProcess);
@@ -67,7 +64,6 @@ export const getGraduationProcessesController = async (req: Request, res: Respon
 export const createDefenseController = async (req: Request, res: Response) => {
   const processId = parseInt(req.params.id);
   const defenseData = req.body;
-
   try {
     const defense = await GraduationProcessInteractor.createDefense(processId, defenseData);
     sendCreated(res, defense, 'Defense created successfully');
@@ -81,7 +77,6 @@ export const createDefenseController = async (req: Request, res: Response) => {
 export const updateDefenseController = async (req: Request, res: Response) => {
   const defenseId = parseInt(req.params.id);
   const updatedData = req.body;
-
   try {
     const defense = await GraduationProcessInteractor.updateDefense(defenseId, updatedData);
     sendSuccess(res, defense, 'Defense updated successfully');
@@ -101,6 +96,19 @@ export const getDefenseController = async (req: Request, res: Response) => {
   } catch (error) {
     if (error instanceof Error) {
       handleError(res, error);
+    }
+  }
+};
+
+export const getTutorsForAssignmentController = async (req: Request, res: Response) => {
+  try {
+    const professors = await ProfessorRepository.getProfessors();
+    sendSuccess(res, professors, 'Tutors retrieved successfully');
+  } catch (error) {
+    if (error instanceof Error) {
+      handleError(res, error);
+    } else {
+      res.status(500).json({ success: false, message: 'Error retrieving tutors' });
     }
   }
 };

--- a/src/controllers/professorController.ts
+++ b/src/controllers/professorController.ts
@@ -15,12 +15,6 @@ const logger = buildLogger('professorController');
 export const getProfessorsController = async (req: Request, res: Response) => {
   try {
     const professors = await ProfessorInteractor.getProfessors();
-
-    if (professors.length === 0) {
-      logger.info('No professors found');
-      return res.status(404).json({ success: false, message: 'No professors found' });
-    }
-
     logger.info('Professors retrieved successfully');
     sendSuccess(res, professors, 'Professors retrieved successfully');
   } catch (error) {
@@ -34,19 +28,15 @@ export const getProfessorsController = async (req: Request, res: Response) => {
 export const createProfessor = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const professorData: createProfessorRequest = req.body;
-
     const codeValue = professorData.code;
     if (typeof codeValue !== 'string' && typeof codeValue !== 'number') {
       throw new BadRequestError('Código inválido. Debe ser numérico.');
     }
-
     const codeStr = String(codeValue);
     if (!/^[0-9]+$/.test(codeStr)) {
       throw new BadRequestError('Código inválido. Debe contener únicamente dígitos (0-9).');
     }
-
     professorData.code = codeStr;
-
     const newProfessor = await ProfessorInteractor.createProfessor(professorData);
     sendCreated(res, { profesor: newProfessor }, 'Professor created successfully');
   } catch (error) {
@@ -90,26 +80,20 @@ export const getThesisStudentsController = async (req: Request, res: Response) =
   try {
     const { supervisorId } = req.params;
     const { type, sortBy = 'date', order = 'desc' } = req.query;
-
     const validSortBy = ['date', 'status'];
     const validOrder = ['asc', 'desc'];
-
     if (sortBy && !validSortBy.includes(sortBy as string)) {
       throw new BadRequestError('Parámetro "sortBy" inválido');
     }
-
     if (order && !validOrder.includes(order as string)) {
       throw new BadRequestError('Parámetro "order" inválido');
     }
-
     const filters = {
       type: type as string | undefined,
       sortBy: sortBy as 'date' | 'status',
       order: order as 'asc' | 'desc',
     };
-
     const result = await getThesisStudentsService(supervisorId, filters);
-
     sendSuccess(res, result, 'Tesistas obtenidos correctamente');
   } catch (error) {
     if (error instanceof Error) {
@@ -123,7 +107,6 @@ export const getProfessorProfileController = async (req: Request, res: Response)
   try {
     const data = await ProfessorInteractor.getProfessorProfile(id);
     const tutorias: any[] = [];
-
     data.graduationData.forEach((tutoria: any) => {
       const row = {
         id: tutoria.id,
@@ -138,7 +121,6 @@ export const getProfessorProfileController = async (req: Request, res: Response)
       };
       tutorias.push(row);
     });
-
     const response: ProfessorProfileResponseDTO = {
       name: data.name,
       lastname: data.lastname,
@@ -147,7 +129,6 @@ export const getProfessorProfileController = async (req: Request, res: Response)
       email: data.email,
       tutorias: tutorias,
     };
-
     sendSuccess(res, response, 'Perfil del profesor obtenido correctamente');
   } catch (error) {
     logger.error(`Error in getProfessorProfileController for id ${id}: ${error}`);

--- a/src/repositories/professorRepository.ts
+++ b/src/repositories/professorRepository.ts
@@ -30,7 +30,6 @@ export const getProfessorById = async (userId: string) => {
       .where('p.id', userId)
       .andWhere('p.disabled', false)
       .first();
-
     return professor || null;
   } catch (error) {
     logger.error(`getProfessorById error for id=${userId}: ${error}`);
@@ -182,9 +181,27 @@ export const getProfessors = async () => {
         'p.degree'
       );
     return professors;
-  } catch (error) {
-    logger.error(`getProfessors error: ${error}`);
-    throw error;
+  } catch (primaryError) {
+    logger.error(`getProfessors primary query error: ${primaryError}`);
+    try {
+      const professorsFallback = await db(`${TABLE_NAME} as p`)
+        .join('users as up', 'p.id', 'up.id')
+        .where('p.disabled', false)
+        .select(
+          'up.id',
+          'up.name',
+          'up.lastname',
+          'up.mothername',
+          'up.email',
+          'up.code',
+          'up.phone',
+          'p.degree'
+        );
+      return professorsFallback;
+    } catch (fallbackError) {
+      logger.error(`getProfessors fallback query error: ${fallbackError}`);
+      throw fallbackError;
+    }
   }
 };
 

--- a/src/routes/graduationRoutes.ts
+++ b/src/routes/graduationRoutes.ts
@@ -1,5 +1,4 @@
 import { Router } from 'express';
-
 import * as GraduationController from '../controllers/graduationController';
 import { checkUserAuth } from '../middlewares/checkUserAuth';
 import { validateParams } from '../middlewares/validateParamsMiddleware';
@@ -39,5 +38,6 @@ router.route('/').get(checkUserAuth, GraduationController.getGraduationProcesses
 router.route('/defense/:id').put(checkUserAuth, GraduationController.updateDefenseController);
 router.route('/:id/defense').post(checkUserAuth, GraduationController.createDefenseController);
 router.route('/:id/defense').get(checkUserAuth, GraduationController.getDefenseController);
+router.route('/:id/tutors').get(checkUserAuth, GraduationController.getTutorsForAssignmentController);
 
 export default router;


### PR DESCRIPTION
## Descripción
Se añadió un endpoint específico para obtener la lista de profesores (tutores) que se pueden asignar en la fase 2 de un proceso de graduación.  
Se corrigió/el fortaleció la consulta de profesores en el repositorio para evitar errores por diferencias en el esquema (`user_profile` vs `users`) y para prevenir que la API devuelva un error 500 en entornos con nombres/estructuras distintas.  
Se ajustó el controlador de profesores para responder siempre con 200 y un array (vacío o con elementos) en lugar de 404 cuando no hay profesores, permitiendo que el frontend maneje el vacío sin considerarlo un error.

## Add
- Ningún archivo nuevo creado.

## Update
1. **src/routes/graduationRoutes.ts**  
   - Se añadió la ruta `GET /api/graduation/:id/tutors` que apunta al nuevo controlador `getTutorsForAssignmentController`.

2. **src/controllers/graduationController.ts**  
   - Se añadió `getTutorsForAssignmentController` que obtiene la lista de tutores desde `professorRepository.getProfessors()` y responde con `sendSuccess`.

3. **src/repositories/professorRepository.ts**  
   - Se mejoró `getProfessors` con manejo robusto: intenta consultar `user_profile` y, si falla (por diferencias de esquema), hace fallback a `users`.  
   - Se añadieron logs de error diferenciados para la consulta principal y el fallback, y se re-lanzan errores solo si ambos intentos fallan.

4. **src/controllers/professorController.ts**  
   - Se modificó `getProfessorsController` para no devolver 404 cuando la lista está vacía; ahora siempre devuelve 200 con el array (vacío o con contenido) y un mensaje de éxito.

## Delete
- Ningún archivo eliminado.

