### PR TITLE
fix(professors): manejar mejor las excepciones con NotFoundError/HttpError

### DIFF
--- a/src/handlers/errorHandler.ts
+++ b/src/handlers/errorHandler.ts
@@ -17,13 +17,18 @@ const errorMap: Record<string, ErrorResponse> = {
   DefaultError: { error: 'Unexpected error. Please try again later', code: 500 },
 };
 
-export const handleError = (res: Response, error: Error) => {
-  const errorResponse = errorMap[error.name] || errorMap['DefaultError'];
-  res.status(errorResponse.code).json({
+export const handleError = (res: Response, error: any) => {
+  const dynamicStatus = typeof error?.statusCode === 'number' ? error.statusCode : undefined;
+
+  const fallback = errorMap[error?.name] || errorMap['DefaultError'];
+  const status = dynamicStatus ?? fallback.code;
+  const label = dynamicStatus ? 'HTTP Error' : fallback.error;
+
+  res.status(status).json({
     success: false,
     data: null,
-    message: error.message,
-    error: errorResponse.error,
-    code: errorResponse.code,
+    message: error?.message || 'Unexpected error',
+    error: label,
+    code: status,
   });
 };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -5,6 +5,8 @@ import config from '../config/config';
 import createUserRequest from '../dtos/createUserRequest';
 import roles from '../constants/roles';
 import { ConflictError } from '../errors/conflictError';
+import { NotFoundError } from '../errors/notFoundError';
+import { HttpError } from '../errors/httpError';
 
 import * as AuthenticationService from './authenticationService';
 
@@ -45,11 +47,19 @@ export const getProfessors = async () => {
   try {
     logger.debug('Attempting to fetch professors');
     const professors = await UserRepository.getProfessors();
+    if (!professors || professors.length === 0) {
+      logger.info('No professors found');
+      throw new NotFoundError('No professors found');
+    }
+
     logger.info('Professors fetched successfully.');
     return professors;
   } catch (error) {
-    logger.error(`Error fetching professors: ${error}`);
-    throw new Error('Error occurred while fetching professors');
+    logger.error(`Error fetching professors: ${(error as Error).message}`);
+    if (error instanceof NotFoundError || error instanceof HttpError) {
+      throw error;
+    }
+    throw new HttpError(502, 'Failed to fetch professors from database');
   }
 };
 


### PR DESCRIPTION
## Contexto
La Fase 5 (defensa externa) necesita listar presidente/primer/segundo jurado desde /api/professors. 
Actualmente, cualquier error se enmascara como 500 genérico (“Unexpected error”), lo que no permite al front distinguir entre “no hay datos” vs “fallo de BD”.

## Cambios
- `userService.getProfessors`:
  - Si no hay resultados → `NotFoundError (404)`.
  - Si hay error del repo/BD → `HttpError(502, 'Failed to fetch professors from database')`.
- `errorHandler`:
  - Respeta `error.statusCode` si existe (para `HttpError`), en lugar de forzar 500.
